### PR TITLE
Adding `stubs` folder

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -92,9 +92,9 @@ function linkLibrariesNvidia()
     includedirs {"$(CUDA_PATH)/include"}
         
     if os.target() == "linux" then
-        libdirs {"$(CUDA_PATH)/lib64"}
+        libdirs {"$(CUDA_PATH)/lib64", "$(CUDA_PATH)/lib64/stubs"}
     else
-        libdirs {"$(CUDA_PATH)/lib/x64"}
+        libdirs {"$(CUDA_PATH)/lib/x64", "$(CUDA_PATH)/lib/x64/stubs"}
     end
     
     if not _OPTIONS["no-opencl"] then


### PR DESCRIPTION
When you install CUDA without driver (e.g. GitHub action machines), libcuda.so is located in `stubs` folder, eventually failing the build with 'cannot find `-lcuda` (see e.g. https://github.com/HiPerCoRe/Umpalumpa/actions/runs/4226102458/jobs/7339175615#step:7:918)`