### PR TITLE
Add tuning of a specific group of compiler options after standard tuning

### DIFF
--- a/Source/Kernel/Kernel.cpp
+++ b/Source/Kernel/Kernel.cpp
@@ -11,6 +11,8 @@
 namespace ktt
 {
 
+static const std::string SeparateCompilerOptionsGroup = "KTTSeparateCompilerOptionsGroup";
+
 Kernel::Kernel(const KernelId id, const std::string& name, const std::vector<const KernelDefinition*>& definitions) :
     m_Id(id),
     m_Name(name),
@@ -241,7 +243,7 @@ std::vector<KernelParameterGroup> Kernel::GenerateParameterGroups() const
 
     for (const auto& parameter : m_Parameters)
     {
-        if (parameter.GetGroup() == "KTTSpecialOptionsGroup")
+        if (parameter.GetGroup() == SeparateCompilerOptionsGroup)
         {
             parameter.SetTuning(false);
         }
@@ -259,13 +261,13 @@ std::vector<KernelParameterGroup> Kernel::GenerateParameterGroups() const
     return result;
 }
 
-std::vector<KernelParameterGroup> Kernel::GenerateSpecialOptionsGroups() const
+std::vector<KernelParameterGroup> Kernel::GenerateSeparateCompilerOptionsGroups() const
 {
     std::vector<const KernelParameter*> specialParameters;
 
     for (const auto& parameter : m_Parameters)
     {
-        if (parameter.GetGroup() == "KTTSpecialOptionsGroup")
+        if (parameter.GetGroup() == SeparateCompilerOptionsGroup)
         {
             parameter.SetTuning(true);
             specialParameters.push_back(&parameter);
@@ -280,7 +282,7 @@ std::vector<KernelParameterGroup> Kernel::GenerateSpecialOptionsGroups() const
     const auto constraints = GetConstraintsForParameters(specialParameters);
 
     return {
-        KernelParameterGroup("KTTSpecialOptionsGroup", specialParameters, constraints)
+        KernelParameterGroup(SeparateCompilerOptionsGroup, specialParameters, constraints)
     };
 }
 

--- a/Source/Kernel/Kernel.cpp
+++ b/Source/Kernel/Kernel.cpp
@@ -241,7 +241,11 @@ std::vector<KernelParameterGroup> Kernel::GenerateParameterGroups() const
 
     for (const auto& parameter : m_Parameters)
     {
-        groupedParameters[parameter.GetGroup()].push_back(&parameter);
+        if (parameter.GetGroup() != "KTTSpecialOptionsGroup")
+        {
+            groupedParameters[parameter.GetGroup()].push_back(&parameter);
+        }
+
     }
 
     std::vector<KernelParameterGroup> result;
@@ -253,6 +257,30 @@ std::vector<KernelParameterGroup> Kernel::GenerateParameterGroups() const
     }
 
     return result;
+}
+
+std::vector<KernelParameterGroup> Kernel::GenerateSpecialOptionsGroups() const
+{
+    std::vector<const KernelParameter*> specialParameters;
+
+    for (const auto& parameter : m_Parameters)
+    {
+        if (parameter.GetGroup() == "KTTSpecialOptionsGroup")
+        {
+            specialParameters.push_back(&parameter);
+        }
+    }
+
+    if (specialParameters.empty())
+    {
+        return {};
+    }
+
+    const auto constraints = GetConstraintsForParameters(specialParameters);
+
+    return {
+        KernelParameterGroup("KTTSpecialOptionsGroup", specialParameters, constraints)
+    };
 }
 
 void Kernel::EnumerateNeighbourConfigurations(const KernelConfiguration& configuration,

--- a/Source/Kernel/Kernel.cpp
+++ b/Source/Kernel/Kernel.cpp
@@ -241,11 +241,11 @@ std::vector<KernelParameterGroup> Kernel::GenerateParameterGroups() const
 
     for (const auto& parameter : m_Parameters)
     {
-        if (parameter.GetGroup() != "KTTSpecialOptionsGroup")
+        if (parameter.GetGroup() == "KTTSpecialOptionsGroup")
         {
-            groupedParameters[parameter.GetGroup()].push_back(&parameter);
+            parameter.SetTuning(false);
         }
-
+        groupedParameters[parameter.GetGroup()].push_back(&parameter);
     }
 
     std::vector<KernelParameterGroup> result;
@@ -267,6 +267,7 @@ std::vector<KernelParameterGroup> Kernel::GenerateSpecialOptionsGroups() const
     {
         if (parameter.GetGroup() == "KTTSpecialOptionsGroup")
         {
+            parameter.SetTuning(true);
             specialParameters.push_back(&parameter);
         }
     }

--- a/Source/Kernel/Kernel.h
+++ b/Source/Kernel/Kernel.h
@@ -52,6 +52,7 @@ public:
 
     KernelConfiguration CreateConfiguration(const ParameterInput& parameters) const;
     std::vector<KernelParameterGroup> GenerateParameterGroups() const;
+    std::vector<KernelParameterGroup> GenerateSpecialOptionsGroups() const;
     void EnumerateNeighbourConfigurations(const KernelConfiguration& configuration,
         std::function<bool(const KernelConfiguration&, const uint64_t)> enumerator) const;
 

--- a/Source/Kernel/Kernel.h
+++ b/Source/Kernel/Kernel.h
@@ -52,7 +52,7 @@ public:
 
     KernelConfiguration CreateConfiguration(const ParameterInput& parameters) const;
     std::vector<KernelParameterGroup> GenerateParameterGroups() const;
-    std::vector<KernelParameterGroup> GenerateSpecialOptionsGroups() const;
+    std::vector<KernelParameterGroup> GenerateSeparateCompilerOptionsGroups() const;
     void EnumerateNeighbourConfigurations(const KernelConfiguration& configuration,
         std::function<bool(const KernelConfiguration&, const uint64_t)> enumerator) const;
 

--- a/Source/Kernel/KernelParameter.cpp
+++ b/Source/Kernel/KernelParameter.cpp
@@ -18,7 +18,8 @@ KernelParameter::KernelParameter(const std::string& name, const std::vector<Para
     m_Name(name),
     m_Group(group),
     m_Values(values),
-    m_IsCompilerParameter(isCompilerParameter)
+    m_IsCompilerParameter(isCompilerParameter),
+    m_IsTuned(true)
 {
     if (values.empty())
     {
@@ -48,7 +49,7 @@ const std::string& KernelParameter::GetGroup() const
 
 size_t KernelParameter::GetValuesCount() const
 {
-    return m_Values.size();
+    return m_IsTuned ? m_Values.size() : 1;
 }
 
 const std::vector<ParameterValue>& KernelParameter::GetValues() const
@@ -90,6 +91,16 @@ std::vector<ParameterPair> KernelParameter::GeneratePairs() const
 bool KernelParameter::IsCompilerParameter() const
 {
     return m_IsCompilerParameter;
+}
+
+bool KernelParameter::IsTuned() const
+{
+    return m_IsTuned;
+}
+
+void KernelParameter::SetTuning(const bool isTuned) const
+{
+    m_IsTuned = isTuned;
 }
 
 bool KernelParameter::operator==(const KernelParameter& other) const

--- a/Source/Kernel/KernelParameter.cpp
+++ b/Source/Kernel/KernelParameter.cpp
@@ -30,6 +30,11 @@ KernelParameter::KernelParameter(const std::string& name, const std::vector<Para
     {
         m_Group = DefaultGroup;
     }
+
+    if (group == "KTTSeparateCompilerOptionsGroup")
+    {
+        m_DefaultValues = { values[0] };
+    }
 }
 
 KernelParameter::KernelParameter(const std::string& name, const ParameterValueType valueType, const std::string& valueScript,
@@ -49,12 +54,12 @@ const std::string& KernelParameter::GetGroup() const
 
 size_t KernelParameter::GetValuesCount() const
 {
-    return m_IsTuned ? m_Values.size() : 1;
+    return m_IsTuned ? m_Values.size() : m_DefaultValues.size();
 }
 
 const std::vector<ParameterValue>& KernelParameter::GetValues() const
 {
-    return m_Values;
+    return m_IsTuned ? m_Values : m_DefaultValues;
 }
 
 ParameterValueType KernelParameter::GetValueType() const

--- a/Source/Kernel/KernelParameter.h
+++ b/Source/Kernel/KernelParameter.h
@@ -41,9 +41,11 @@ private:
     std::vector<ParameterValue> m_Values;
     bool m_IsCompilerParameter;
 
-    // If the parameter is not tuned with the others, only its first value will be used in the configurations.
+    // If the parameter is not tuned with the others, only its default values will be used in the configurations.
+    // Currently, default value is just its first value from m_Values.
     // Used for compiler options that will be tuned separately after standard tuning.
     mutable bool m_IsTuned;
+    std::vector<ParameterValue> m_DefaultValues;
 
     static std::vector<ParameterValue> GetValuesFromScript(const ParameterValueType valueType, const std::string& valueScript);
 };

--- a/Source/Kernel/KernelParameter.h
+++ b/Source/Kernel/KernelParameter.h
@@ -27,6 +27,9 @@ public:
     ParameterPair GeneratePair(const size_t valueIndex) const;
     std::vector<ParameterPair> GeneratePairs() const;
     bool IsCompilerParameter() const;
+    bool IsTuned() const;
+
+    void SetTuning(const bool isTuned) const;
 
     bool operator==(const KernelParameter& other) const;
     bool operator!=(const KernelParameter& other) const;
@@ -37,6 +40,10 @@ private:
     std::string m_Group;
     std::vector<ParameterValue> m_Values;
     bool m_IsCompilerParameter;
+
+    // If the parameter is not tuned with the others, only its first value will be used in the configurations.
+    // Used for compiler options that will be tuned separately after standard tuning.
+    mutable bool m_IsTuned;
 
     static std::vector<ParameterValue> GetValuesFromScript(const ParameterValueType valueType, const std::string& valueScript);
 };

--- a/Source/Python/PythonTuner.cpp
+++ b/Source/Python/PythonTuner.cpp
@@ -177,6 +177,15 @@ void InitializePythonTuner(py::module_& module)
             py::arg("name"),
             py::arg("values") = std::vector<std::string>{}
         )
+        .def
+        (
+            "AddScriptSepatateCompilerParameter",
+            &ktt::Tuner::AddScriptSeparateCompilerParameter,
+            py::arg("id"),
+            py::arg("name"),
+            py::arg("valueType"),
+            py::arg("valueScript"),
+        )
         .def("AddThreadModifier", py::overload_cast<const ktt::KernelId, const std::vector<ktt::KernelDefinitionId>&, const ktt::ModifierType,
             const ktt::ModifierDimension, const std::vector<std::string>&, ktt::ModifierFunction>(&ktt::Tuner::AddThreadModifier))
         .def("AddThreadModifier", py::overload_cast<const ktt::KernelId, const std::vector<ktt::KernelDefinitionId>&, const ktt::ModifierType,

--- a/Source/Python/PythonTuner.cpp
+++ b/Source/Python/PythonTuner.cpp
@@ -169,6 +169,14 @@ void InitializePythonTuner(py::module_& module)
             py::arg("valueScript"),
             py::arg("group") = std::string()
         )
+        .def
+        (
+            "AddSeparateCompilerParameter",
+            &ktt::Tuner::AddSeparateCompilerParameter,
+            py::arg("id"),
+            py::arg("name"),
+            py::arg("values") = std::vector<std::string>{}
+        )
         .def("AddThreadModifier", py::overload_cast<const ktt::KernelId, const std::vector<ktt::KernelDefinitionId>&, const ktt::ModifierType,
             const ktt::ModifierDimension, const std::vector<std::string>&, ktt::ModifierFunction>(&ktt::Tuner::AddThreadModifier))
         .def("AddThreadModifier", py::overload_cast<const ktt::KernelId, const std::vector<ktt::KernelDefinitionId>&, const ktt::ModifierType,
@@ -506,6 +514,26 @@ void InitializePythonTuner(py::module_& module)
             py::overload_cast<const ktt::KernelId, const ktt::KernelDimensions&, std::unique_ptr<ktt::StopCondition>>(&ktt::Tuner::Tune),
             py::call_guard<py::gil_scoped_release>(),
             py::arg("id"),
+            py::arg("dimensions"),
+            py::arg("stopCondition") = nullptr
+        )
+        .def
+        (
+            "TuneOptions",
+            py::overload_cast<const ktt::KernelId, const ktt::KernelConfiguration&, std::unique_ptr<ktt::StopCondition>>(&ktt::Tuner::TuneOptions),
+            py::call_guard<py::gil_scoped_release>(),
+            py::arg("id"),
+            py::arg("baseConfiguration"),
+            py::arg("stopCondition") = nullptr
+        )
+        .def
+        (
+            "TuneOptions",
+            py::overload_cast<const ktt::KernelId, const ktt::KernelConfiguration&, const ktt::KernelDimensions&,
+                std::unique_ptr<ktt::StopCondition>>(&ktt::Tuner::TuneOptions),
+            py::call_guard<py::gil_scoped_release>(),
+            py::arg("id"),
+            py::arg("baseConfiguration"),
             py::arg("dimensions"),
             py::arg("stopCondition") = nullptr
         )

--- a/Source/Tuner.cpp
+++ b/Source/Tuner.cpp
@@ -551,6 +551,27 @@ std::vector<KernelResult> Tuner::Tune(const KernelId id, const KernelDimensions&
     }
 }
 
+std::vector<KernelResult> Tuner::TuneOptions(const KernelId id, const KernelConfiguration& baseConfiguration,
+    std::unique_ptr<StopCondition> stopCondition, const std::optional<PreciseMeasurementParameters>& preciseParams)
+{
+    return TuneOptions(id, baseConfiguration, {}, std::move(stopCondition), preciseParams);
+}
+
+std::vector<KernelResult> Tuner::TuneOptions(const KernelId id, const KernelConfiguration& baseConfiguration,
+    const KernelDimensions& dimensions, std::unique_ptr<StopCondition> stopCondition,
+    const std::optional<PreciseMeasurementParameters>& preciseParams)
+{
+    try
+    {
+        return m_Tuner->TuneOptions(id, baseConfiguration, dimensions, std::move(stopCondition), preciseParams);
+    }
+    catch (const KttException& exception)
+    {
+        TunerCore::Log(LoggingLevel::Error, exception.what());
+        return std::vector<KernelResult>{};
+    }
+}
+
 KernelResult Tuner::TuneIteration(const KernelId id, const std::vector<BufferOutputDescriptor>& output,
     const bool recomputeReference, const std::optional<PreciseMeasurementParameters>& preciseParams)
 {

--- a/Source/Tuner.cpp
+++ b/Source/Tuner.cpp
@@ -193,6 +193,12 @@ void Tuner::AddScriptCompilerParameter(const KernelId id, const std::string& nam
     }
 }
 
+void Tuner::AddScriptSeparateCompilerParameter(const KernelId id, const std::string& name, const ParameterValueType valueType,
+    const std::string& valueScript)
+{
+    AddScriptCompilerParameter(id, name, valueType, valueScript, "KTTSeparateCompilerOptionsGroup");
+}
+
 void Tuner::AddThreadModifier(const KernelId id, const std::vector<KernelDefinitionId>& definitionIds, const ModifierType type,
     const ModifierDimension dimension, const std::vector<std::string>& parameters, ModifierFunction function)
 {

--- a/Source/Tuner.cpp
+++ b/Source/Tuner.cpp
@@ -1082,6 +1082,11 @@ void Tuner::AddCompilerParameter(const KernelId id, const std::string& name, con
     AddParameterInternal(id, name, parameterValues, group, isCompilerParameter);
 }
 
+void Tuner::AddSeparateCompilerParameter(const KernelId id, const std::string& name, const std::vector<std::string>& values)
+{
+    AddCompilerParameter(id, name, values, "KTTSeparateCompilerOptionsGroup");
+}
+
 void Tuner::AddParameterInternal(const KernelId id, const std::string& name, const std::vector<ParameterValue>& values,
     const std::string& group, const bool isCompilerParameter)
 {

--- a/Source/Tuner.h
+++ b/Source/Tuner.h
@@ -241,13 +241,23 @@ public:
       * @param id Id of kernel for which the parameter will be added.
       * @param name Name of a parameter. Parameter names for a single kernel must be unique.
       * @param values Optional allowed values for the parameter. Value type is a string. If left empty, parameter with be either
-      * included without any value or completely excluded.
+      * present without any value or completely excluded.
       * @param group Optional group inside which the parameter will be added. Tuning configurations are generated separately for each
       * group. This is useful when kernels contain groups of parameters that can be tuned independently. In this way, the total number
       * of generated configurations can be significantly reduced.
       */
     void AddCompilerParameter(const KernelId id, const std::string& name, const std::vector<std::string>& values = {},
         const std::string& group = "");
+
+    /** @fn void AddSeparateCompilerParameter(const KernelId id, const std::string& name, const std::vector<std::string>& values = {})
+      * Works like AddCompilerParameter(), but compiler options added through this function, will be tuned separately (after standard tuning).
+      * These compiler optinos can be tuned with TuneOptions() function.
+      * @param id Id of kernel for which the parameter will be added.
+      * @param name Name of a parameter. Parameter names for a single kernel must be unique.
+      * @param values Optional allowed values for the parameter. Value type is a string. If left empty, parameter with be either
+      * present without any value or completely excluded.
+      */
+    void AddSeparateCompilerParameter(const KernelId id, const std::string& name, const std::vector<std::string>& values = {});
 
     /** @fn void AddScriptParameter(const KernelId id, const std::string& name, const ParameterValueType valueType,
       * const std::string& valueScript, const std::string& group = "")
@@ -706,12 +716,13 @@ public:
         std::unique_ptr<StopCondition> stopCondition = nullptr,
         const std::optional<PreciseMeasurementParameters>& preciseParams = std::nullopt);
 
-    /** @fn std::vector<KernelResult> Tune(const KernelId id, std::unique_ptr<StopCondition> stopCondition = nullptr,
+    /** @fn std::vector<KernelResult> TuneOptions(const KernelId id, const KernelConfiguration& baseConfiguration,
+      * std::unique_ptr<StopCondition> stopCondition = nullptr,
       * const std::optional<PreciseMeasurementParameters>& preciseParams = std::nullopt)
-      * Performs the tuning process for specified kernel. Creates configuration space based on combinations of provided kernel
-      * parameters and constraints. The configurations will be launched in order that depends on the specified Searcher. Tuning
-      * will end either when all configurations are explored or when the specified stop condition is fulfilled.
+      * Works simiraliry to Tune(), but is used for tuning compiler options separately.
+      * These options can be added through function AddSeparateCompilerParameter().
       * @param id Id of the tuned kernel.
+      * @param baseConfiguration Configuration on top of which compiler options will be tuned.
       * @param stopCondition Condition which decides whether to continue the tuning process. If no condition is provided, tuning
       * will end when all configurations are explored. See StopCondition for more information.
       * @param powerParams Optional parameters for robust power measurement. If not provided, kernel is executed once per configuration.
@@ -720,18 +731,17 @@ public:
       * @return Vector of results containing information about kernel computation in specific configuration. See KernelResult for
       * more information.
       */
-    // TODO: TuneOptions description
     std::vector<KernelResult> TuneOptions(const KernelId id, const KernelConfiguration& baseConfiguration,
         std::unique_ptr<StopCondition> stopCondition = nullptr,
         const std::optional<PreciseMeasurementParameters>& preciseParams = std::nullopt);
 
-    /** @fn std::vector<KernelResult> Tune(const KernelId id, const KernelDimensions& dimensions,
-      * std::unique_ptr<StopCondition> stopCondition = nullptr,
+    /** @fn std::vector<KernelResult> TuneOptions(const KernelId id, const KernelConfiguration& baseConfiguration,
+      * const KernelDimensions& dimensions, std::unique_ptr<StopCondition> stopCondition = nullptr,
       * const std::optional<PreciseMeasurementParameters>& preciseParams = std::nullopt)
-      * Performs the tuning process for specified kernel. Creates configuration space based on combinations of provided kernel
-      * parameters and constraints. The configurations will be launched in order that depends on the specified Searcher. Tuning
-      * will end either when all configurations are explored or when the specified stop condition is fulfilled.
+      * Works simiraliry to Tune(), but is used for tuning compiler options separately.
+      * These options can be added through function AddSeparateCompilerParameter().
       * @param id Id of the tuned kernel.
+      * @param baseConfiguration Configuration on top of which compiler options will be tuned.
       * @param dimensions Global and local sizes with which the kernel will be launched. If no dimensions are specified for some
       * definition, the sizes specified during its addition will be used.
       * @param stopCondition Condition which decides whether to continue the tuning process. If no condition is provided, tuning
@@ -743,8 +753,7 @@ public:
       * more information.
       */
     std::vector<KernelResult> TuneOptions(const KernelId id, const KernelConfiguration& baseConfiguration,
-        const KernelDimensions& dimensions,
-        std::unique_ptr<StopCondition> stopCondition = nullptr,
+        const KernelDimensions& dimensions, std::unique_ptr<StopCondition> stopCondition = nullptr,
         const std::optional<PreciseMeasurementParameters>& preciseParams = std::nullopt);
 
     /** @fn KernelResult TuneIteration(const KernelId id, const std::vector<BufferOutputDescriptor>& output,

--- a/Source/Tuner.h
+++ b/Source/Tuner.h
@@ -294,6 +294,19 @@ public:
     void AddScriptCompilerParameter(const KernelId id, const std::string& name, const ParameterValueType valueType, const std::string& valueScript,
         const std::string& group = "");
 
+    /** @fn void AddScriptSeparateCompilerParameter(const KernelId id, const std::string& name, const ParameterValueType valueType,
+      * const std::string& valueScript)
+      * Works similarily to AddScriptCompilerParameter(), but for compiler parameters that are tuned separately.
+      * For standard tuning, only its first value will be used. Other values can be tuned with TuneOptions.
+      * @param id Id of kernel for which the parameter will be added.
+      * @param name Name of a parameter. Parameter names for a single kernel must be unique.
+      * @param valueType Type of parameter values.
+      * @param valueScript Python script which will be executed to generate a list of parameter values. The values of the tuning parameters
+      * can be utilized by the script. The default thread size can be accessed from script through variable named "defaultSize".
+      */
+    void AddScriptSeparateCompilerParameter(const KernelId id, const std::string& name, const ParameterValueType valueType,
+        const std::string& valueScript);
+
     /** @fn void AddThreadModifier(const KernelId id, const std::vector<KernelDefinitionId>& definitionIds, const ModifierType type,
       * const ModifierDimension dimension, const std::vector<std::string>& parameters, ModifierFunction function)
       * Adds thread modifier function for the specified kernel. The function receives thread size in the specified dimension and

--- a/Source/Tuner.h
+++ b/Source/Tuner.h
@@ -706,6 +706,47 @@ public:
         std::unique_ptr<StopCondition> stopCondition = nullptr,
         const std::optional<PreciseMeasurementParameters>& preciseParams = std::nullopt);
 
+    /** @fn std::vector<KernelResult> Tune(const KernelId id, std::unique_ptr<StopCondition> stopCondition = nullptr,
+      * const std::optional<PreciseMeasurementParameters>& preciseParams = std::nullopt)
+      * Performs the tuning process for specified kernel. Creates configuration space based on combinations of provided kernel
+      * parameters and constraints. The configurations will be launched in order that depends on the specified Searcher. Tuning
+      * will end either when all configurations are explored or when the specified stop condition is fulfilled.
+      * @param id Id of the tuned kernel.
+      * @param stopCondition Condition which decides whether to continue the tuning process. If no condition is provided, tuning
+      * will end when all configurations are explored. See StopCondition for more information.
+      * @param powerParams Optional parameters for robust power measurement. If not provided, kernel is executed once per configuration.
+      * If provided, robust power measurement is enabled (CUDA with NVML support only, requires --power-usage build option).
+      * Throws KttException if power measurement is requested but not supported.
+      * @return Vector of results containing information about kernel computation in specific configuration. See KernelResult for
+      * more information.
+      */
+    // TODO: TuneOptions description
+    std::vector<KernelResult> TuneOptions(const KernelId id, const KernelConfiguration& baseConfiguration,
+        std::unique_ptr<StopCondition> stopCondition = nullptr,
+        const std::optional<PreciseMeasurementParameters>& preciseParams = std::nullopt);
+
+    /** @fn std::vector<KernelResult> Tune(const KernelId id, const KernelDimensions& dimensions,
+      * std::unique_ptr<StopCondition> stopCondition = nullptr,
+      * const std::optional<PreciseMeasurementParameters>& preciseParams = std::nullopt)
+      * Performs the tuning process for specified kernel. Creates configuration space based on combinations of provided kernel
+      * parameters and constraints. The configurations will be launched in order that depends on the specified Searcher. Tuning
+      * will end either when all configurations are explored or when the specified stop condition is fulfilled.
+      * @param id Id of the tuned kernel.
+      * @param dimensions Global and local sizes with which the kernel will be launched. If no dimensions are specified for some
+      * definition, the sizes specified during its addition will be used.
+      * @param stopCondition Condition which decides whether to continue the tuning process. If no condition is provided, tuning
+      * will end when all configurations are explored. See StopCondition for more information.
+      * @param powerParams Optional parameters for robust power measurement. If not provided, kernel is executed once per configuration.
+      * If provided, robust power measurement is enabled (CUDA with NVML support only, requires --power-usage build option).
+      * Throws KttException if power measurement is requested but not supported.
+      * @return Vector of results containing information about kernel computation in specific configuration. See KernelResult for
+      * more information.
+      */
+    std::vector<KernelResult> TuneOptions(const KernelId id, const KernelConfiguration& baseConfiguration,
+        const KernelDimensions& dimensions,
+        std::unique_ptr<StopCondition> stopCondition = nullptr,
+        const std::optional<PreciseMeasurementParameters>& preciseParams = std::nullopt);
+
     /** @fn KernelResult TuneIteration(const KernelId id, const std::vector<BufferOutputDescriptor>& output,
       * const bool recomputeReference = false, const std::optional<PreciseMeasurementParameters>& preciseParams = std::nullopt)
       * Performs one step of the tuning process for specified kernel. When this method is called for the kernel for the first time,

--- a/Source/TunerCore.cpp
+++ b/Source/TunerCore.cpp
@@ -269,7 +269,7 @@ std::vector<KernelResult> TunerCore::TuneKernel(const KernelId id, const KernelD
     std::unique_ptr<StopCondition> stopCondition, const std::optional<PreciseMeasurementParameters>& preciseParams)
 {
     const auto& kernel = m_KernelManager->GetKernel(id);
-    return m_TuningRunner->Tune(kernel, dimensions, std::move(stopCondition), preciseParams);
+    return m_TuningRunner->Tune(kernel, dimensions, std::move(stopCondition), preciseParams, false, {});
 }
 
 std::vector<KernelResult> TunerCore::TuneOptions(const KernelId id, const KernelConfiguration& baseConfiguration,
@@ -277,7 +277,7 @@ std::vector<KernelResult> TunerCore::TuneOptions(const KernelId id, const Kernel
     const std::optional<PreciseMeasurementParameters>& preciseParams)
 {
     const auto& kernel = m_KernelManager->GetKernel(id);
-    return m_TuningRunner->TuneOptions(kernel, baseConfiguration, dimensions, std::move(stopCondition), preciseParams);
+    return m_TuningRunner->Tune(kernel, dimensions, std::move(stopCondition), preciseParams, true, baseConfiguration);
 }
 
 KernelResult TunerCore::TuneKernelIteration(const KernelId id, const KernelDimensions& dimensions,

--- a/Source/TunerCore.cpp
+++ b/Source/TunerCore.cpp
@@ -272,6 +272,14 @@ std::vector<KernelResult> TunerCore::TuneKernel(const KernelId id, const KernelD
     return m_TuningRunner->Tune(kernel, dimensions, std::move(stopCondition), preciseParams);
 }
 
+std::vector<KernelResult> TunerCore::TuneOptions(const KernelId id, const KernelConfiguration& baseConfiguration,
+    const KernelDimensions& dimensions, std::unique_ptr<StopCondition> stopCondition,
+    const std::optional<PreciseMeasurementParameters>& preciseParams)
+{
+    const auto& kernel = m_KernelManager->GetKernel(id);
+    return m_TuningRunner->TuneOptions(kernel, baseConfiguration, dimensions, std::move(stopCondition), preciseParams);
+}
+
 KernelResult TunerCore::TuneKernelIteration(const KernelId id, const KernelDimensions& dimensions,
     const std::vector<BufferOutputDescriptor>& output, const bool recomputeReference,
     const std::optional<PreciseMeasurementParameters>& preciseParams)

--- a/Source/TunerCore.h
+++ b/Source/TunerCore.h
@@ -90,6 +90,9 @@ public:
     // Kernel tuning and configurations
     std::vector<KernelResult> TuneKernel(const KernelId id, const KernelDimensions& dimensions, std::unique_ptr<StopCondition> stopCondition,
         const std::optional<PreciseMeasurementParameters>& preciseParams = std::nullopt);
+    std::vector<KernelResult> TuneOptions(const KernelId id, const KernelConfiguration& baseConfiguration,
+        const KernelDimensions& dimensions, std::unique_ptr<StopCondition> stopCondition,
+        const std::optional<PreciseMeasurementParameters>& preciseParams = std::nullopt);
     KernelResult TuneKernelIteration(const KernelId id, const KernelDimensions& dimensions, const std::vector<BufferOutputDescriptor>& output,
         const bool recomputeReference, const std::optional<PreciseMeasurementParameters>& preciseParams = std::nullopt);
     std::vector<KernelResult> SimulateKernelTuning(const KernelId id, const std::vector<KernelResult>& results,

--- a/Source/TuningRunner/ConfigurationData.cpp
+++ b/Source/TuningRunner/ConfigurationData.cpp
@@ -14,13 +14,13 @@
 namespace ktt
 {
 
-ConfigurationData::ConfigurationData(Searcher& searcher, const Kernel& kernel, const bool isSpecialGroup,
+ConfigurationData::ConfigurationData(Searcher& searcher, const Kernel& kernel, const bool isSeparateOptionsGroup,
     const KernelConfiguration& baseConfiguration) :
     m_BestConfiguration({KernelConfiguration(), InvalidDuration}),
     m_Searcher(searcher),
     m_Kernel(kernel),
     m_SearcherActive(false),
-    m_IsSpecialGroup(isSpecialGroup),
+    m_IsSeparateOptionsGroup(isSeparateOptionsGroup),
     m_BaseConfiguration(baseConfiguration)
 {
     InitializeConfigurations();
@@ -225,14 +225,15 @@ KernelConfiguration ConfigurationData::GetBestConfiguration() const
     return GetCurrentConfiguration();
 }
 
-bool ConfigurationData::IsSpecialGroup() const
+bool ConfigurationData::IsSeparateOptionsGroup() const
 {
-    return m_IsSpecialGroup;
+    return m_IsSeparateOptionsGroup;
 }
 
 void ConfigurationData::InitializeConfigurations()
 {
-    const auto groups = m_IsSpecialGroup ? m_Kernel.GenerateSpecialOptionsGroups() : m_Kernel.GenerateParameterGroups();
+    const auto groups = IsSeparateOptionsGroup() ? m_Kernel.GenerateSeparateCompilerOptionsGroups()
+                                                 : m_Kernel.GenerateParameterGroups();
     Logger::LogInfo("Generating configurations for kernel " + m_Kernel.GetName());
 
     Timer timer;

--- a/Source/TuningRunner/ConfigurationData.cpp
+++ b/Source/TuningRunner/ConfigurationData.cpp
@@ -14,11 +14,14 @@
 namespace ktt
 {
 
-ConfigurationData::ConfigurationData(Searcher& searcher, const Kernel& kernel) :
+ConfigurationData::ConfigurationData(Searcher& searcher, const Kernel& kernel, const bool isSpecialGroup,
+    const KernelConfiguration& baseConfiguration) :
     m_BestConfiguration({KernelConfiguration(), InvalidDuration}),
     m_Searcher(searcher),
     m_Kernel(kernel),
-    m_SearcherActive(false)
+    m_SearcherActive(false),
+    m_IsSpecialGroup(isSpecialGroup),
+    m_BaseConfiguration(baseConfiguration)
 {
     InitializeConfigurations();
 }
@@ -222,9 +225,14 @@ KernelConfiguration ConfigurationData::GetBestConfiguration() const
     return GetCurrentConfiguration();
 }
 
+bool ConfigurationData::IsSpecialGroup() const
+{
+    return m_IsSpecialGroup;
+}
+
 void ConfigurationData::InitializeConfigurations()
 {
-    const auto groups = m_Kernel.GenerateParameterGroups();
+    const auto groups = m_IsSpecialGroup ? m_Kernel.GenerateSpecialOptionsGroups() : m_Kernel.GenerateParameterGroups();
     Logger::LogInfo("Generating configurations for kernel " + m_Kernel.GetName());
 
     Timer timer;
@@ -253,7 +261,7 @@ void ConfigurationData::InitializeConfigurations()
     Logger::LogInfo("Total count of " + std::to_string(GetTotalConfigurationsCount()) + " configurations was generated in "
         + std::to_string(elapsedTime) + time.GetUnitTag());
 
-    KernelConfiguration initialBest;
+    KernelConfiguration initialBest = m_BaseConfiguration;
 
     for (const auto& forest : m_Forests)
     {

--- a/Source/TuningRunner/ConfigurationData.h
+++ b/Source/TuningRunner/ConfigurationData.h
@@ -17,7 +17,8 @@ namespace ktt
 class ConfigurationData
 {
 public:
-    explicit ConfigurationData(Searcher& searcher, const Kernel& kernel);
+    explicit ConfigurationData(Searcher& searcher, const Kernel& kernel, const bool isSpecialGroup = false,
+        const KernelConfiguration& baseConfiguration = KernelConfiguration());
     ~ConfigurationData();
 
     bool CalculateNextConfiguration(const KernelResult& previousResult);
@@ -36,6 +37,8 @@ public:
     KernelConfiguration GetCurrentConfiguration() const;
     KernelConfiguration GetBestConfiguration() const;
 
+    bool IsSpecialGroup() const;
+
 private:
     std::vector<std::unique_ptr<ConfigurationForest>> m_Forests;
     std::set<uint64_t> m_ExploredConfigurations;
@@ -44,6 +47,8 @@ private:
     Searcher& m_Searcher;
     const Kernel& m_Kernel;
     bool m_SearcherActive;
+    bool m_IsSpecialGroup;
+    KernelConfiguration m_BaseConfiguration;
 
     void InitializeConfigurations();
     void UpdateBestConfiguration(const KernelResult& previousResult);

--- a/Source/TuningRunner/ConfigurationData.h
+++ b/Source/TuningRunner/ConfigurationData.h
@@ -17,7 +17,7 @@ namespace ktt
 class ConfigurationData
 {
 public:
-    explicit ConfigurationData(Searcher& searcher, const Kernel& kernel, const bool isSpecialGroup = false,
+    explicit ConfigurationData(Searcher& searcher, const Kernel& kernel, const bool isSeparateOptionsGroup = false,
         const KernelConfiguration& baseConfiguration = KernelConfiguration());
     ~ConfigurationData();
 
@@ -37,7 +37,7 @@ public:
     KernelConfiguration GetCurrentConfiguration() const;
     KernelConfiguration GetBestConfiguration() const;
 
-    bool IsSpecialGroup() const;
+    bool IsSeparateOptionsGroup() const;
 
 private:
     std::vector<std::unique_ptr<ConfigurationForest>> m_Forests;
@@ -47,7 +47,7 @@ private:
     Searcher& m_Searcher;
     const Kernel& m_Kernel;
     bool m_SearcherActive;
-    bool m_IsSpecialGroup;
+    bool m_IsSeparateOptionsGroup;
     KernelConfiguration m_BaseConfiguration;
 
     void InitializeConfigurations();

--- a/Source/TuningRunner/ConfigurationManager.cpp
+++ b/Source/TuningRunner/ConfigurationManager.cpp
@@ -22,7 +22,8 @@ void ConfigurationManager::SetSearcher(const KernelId id, std::unique_ptr<Search
     m_Searchers[id] = std::move(searcher);
 }
 
-void ConfigurationManager::InitializeData(const Kernel& kernel)
+void ConfigurationManager::InitializeData(const Kernel& kernel, const bool isSpecialGroup,
+    const KernelConfiguration& baseConfiguration)
 {
     const auto id = kernel.GetId();
     Logger::LogDebug("Initializing configuration data for kernel " + kernel.GetName());
@@ -32,7 +33,7 @@ void ConfigurationManager::InitializeData(const Kernel& kernel)
         m_Searchers[id] = std::make_unique<DeterministicSearcher>();
     }
 
-    m_ConfigurationData[id] = std::make_unique<ConfigurationData>(*m_Searchers[id], kernel);
+    m_ConfigurationData[id] = std::make_unique<ConfigurationData>(*m_Searchers[id], kernel, isSpecialGroup, baseConfiguration);
 }
 
 void ConfigurationManager::ClearData(const KernelId id, const bool clearSearcher)

--- a/Source/TuningRunner/ConfigurationManager.cpp
+++ b/Source/TuningRunner/ConfigurationManager.cpp
@@ -22,7 +22,7 @@ void ConfigurationManager::SetSearcher(const KernelId id, std::unique_ptr<Search
     m_Searchers[id] = std::move(searcher);
 }
 
-void ConfigurationManager::InitializeData(const Kernel& kernel, const bool isSpecialGroup,
+void ConfigurationManager::InitializeData(const Kernel& kernel, const bool isSeparateOptionsGroup,
     const KernelConfiguration& baseConfiguration)
 {
     const auto id = kernel.GetId();
@@ -33,7 +33,7 @@ void ConfigurationManager::InitializeData(const Kernel& kernel, const bool isSpe
         m_Searchers[id] = std::make_unique<DeterministicSearcher>();
     }
 
-    m_ConfigurationData[id] = std::make_unique<ConfigurationData>(*m_Searchers[id], kernel, isSpecialGroup, baseConfiguration);
+    m_ConfigurationData[id] = std::make_unique<ConfigurationData>(*m_Searchers[id], kernel, isSeparateOptionsGroup, baseConfiguration);
 }
 
 void ConfigurationManager::ClearData(const KernelId id, const bool clearSearcher)

--- a/Source/TuningRunner/ConfigurationManager.h
+++ b/Source/TuningRunner/ConfigurationManager.h
@@ -20,7 +20,7 @@ public:
     ConfigurationManager();
 
     void SetSearcher(const KernelId id, std::unique_ptr<Searcher> searcher);
-    void InitializeData(const Kernel& kernel, const bool isSpecialGroup = false,
+    void InitializeData(const Kernel& kernel, const bool isSeparateOptionsGroup = false,
         const KernelConfiguration& baseConfiguration = KernelConfiguration());
     void ClearData(const KernelId id, const bool clearSearcher = false);
     bool CalculateNextConfiguration(const KernelId id, const KernelResult& previousResult);

--- a/Source/TuningRunner/ConfigurationManager.h
+++ b/Source/TuningRunner/ConfigurationManager.h
@@ -20,7 +20,8 @@ public:
     ConfigurationManager();
 
     void SetSearcher(const KernelId id, std::unique_ptr<Searcher> searcher);
-    void InitializeData(const Kernel& kernel);
+    void InitializeData(const Kernel& kernel, const bool isSpecialGroup = false,
+        const KernelConfiguration& baseConfiguration = KernelConfiguration());
     void ClearData(const KernelId id, const bool clearSearcher = false);
     bool CalculateNextConfiguration(const KernelId id, const KernelResult& previousResult);
     void ListConfigurations(const KernelId id) const;

--- a/Source/TuningRunner/TuningRunner.cpp
+++ b/Source/TuningRunner/TuningRunner.cpp
@@ -82,6 +82,74 @@ std::vector<KernelResult> TuningRunner::Tune(const Kernel& kernel, const KernelD
     return results;
 }
 
+std::vector<KernelResult> TuningRunner::TuneOptions(const Kernel& kernel, const KernelConfiguration& baseConfiguration,
+    const KernelDimensions& dimensions, std::unique_ptr<StopCondition> stopCondition,
+    const std::optional<PreciseMeasurementParameters>& preciseParams)
+{
+    Logger::LogInfo("Starting options tuning for kernel " + kernel.GetName());
+    const auto id = kernel.GetId();
+    m_ConfigurationManager->ClearData(id, true);
+
+    if (!m_ConfigurationManager->HasData(id))
+    {
+        m_ConfigurationManager->InitializeData(kernel, true, baseConfiguration);
+    }
+
+    if (stopCondition != nullptr)
+    {
+        const uint64_t configurationsCount = m_ConfigurationManager->GetTotalConfigurationsCount(id);
+        stopCondition->Initialize(configurationsCount);
+    }
+
+    std::vector<KernelResult> results;
+
+    while (!m_ConfigurationManager->IsDataProcessed(id))
+    {
+        KernelResult result(kernel.GetName(), m_ConfigurationManager->GetCurrentConfiguration(id), "");
+        KernelResult multiResult(kernel.GetName(), m_ConfigurationManager->GetCurrentConfiguration(id), ktt::Timestamp::GetTimestamp());
+        int iter = 0;
+        do
+        {
+            result = TuneIteration(kernel, dimensions, KernelRunMode::OfflineTuning, std::vector<BufferOutputDescriptor>{}, false, preciseParams);
+            multiResult.FuseProfilingTimes(result, (iter == 0));
+            multiResult.TransferPowerData(result);
+            iter++;
+        }
+        while (result.HasRemainingProfilingRuns());
+        if (iter > 1) //do not copy the same result twice
+        {
+            result.CopyProfilingTimes(multiResult);
+            result.TransferPowerData(multiResult);
+        }
+
+        const Nanoseconds searcherOverhead = RunScopeTimer([this, id, &result]()
+        {
+            m_ConfigurationManager->CalculateNextConfiguration(id, result);
+        });
+
+        result.SetSearcherOverhead(searcherOverhead);
+        results.push_back(result);
+
+        if (stopCondition == nullptr)
+        {
+            continue;
+        }
+
+        stopCondition->Update(result);
+        Logger::LogInfo(stopCondition->GetStatusString());
+
+        if (stopCondition->IsFulfilled())
+        {
+            break;
+        }
+    }
+
+    Logger::LogInfo("Ending options tuning for kernel " + kernel.GetName() + ", total number of tested configurations is "
+        + std::to_string(results.size()));
+    m_KernelRunner.ClearReferenceResult(kernel);
+    return results;
+}
+
 KernelResult TuningRunner::TuneIteration(const Kernel& kernel, const KernelDimensions& dimensions, const KernelRunMode mode,
     const std::vector<BufferOutputDescriptor>& output, const bool recomputeReference,
     const std::optional<PreciseMeasurementParameters>& preciseParams)

--- a/Source/TuningRunner/TuningRunner.cpp
+++ b/Source/TuningRunner/TuningRunner.cpp
@@ -16,14 +16,27 @@ TuningRunner::TuningRunner(KernelRunner& kernelRunner) :
 {}
 
 std::vector<KernelResult> TuningRunner::Tune(const Kernel& kernel, const KernelDimensions& dimensions,
-    std::unique_ptr<StopCondition> stopCondition, const std::optional<PreciseMeasurementParameters>& preciseParams)
+    std::unique_ptr<StopCondition> stopCondition, const std::optional<PreciseMeasurementParameters>& preciseParams,
+    const bool tuneOptions, const KernelConfiguration& baseConfiguration)
 {
-    Logger::LogInfo("Starting offline tuning for kernel " + kernel.GetName());
+    // When tuneOptions is true, only parameters provided by Tuner::AddSeparateCompilerParameter() are tuned;
+    // other parameters are provided by baseConfiguration and are not tuned.
+    // When tuneOptions is false, these separate compiler parameters are not tuned,
+    // and only their single default value is included in the tuning space.
+    const std::string tuningMode = tuneOptions ? "options" : "offline";
+
+    Logger::LogInfo("Starting " + tuningMode + " tuning for kernel " + kernel.GetName());
+
     const auto id = kernel.GetId();
+
+    if (tuneOptions)
+    {
+        m_ConfigurationManager->ClearData(id, true);
+    }
 
     if (!m_ConfigurationManager->HasData(id))
     {
-        m_ConfigurationManager->InitializeData(kernel);
+        m_ConfigurationManager->InitializeData(kernel, tuneOptions, baseConfiguration);
     }
 
     if (stopCondition != nullptr)
@@ -34,74 +47,6 @@ std::vector<KernelResult> TuningRunner::Tune(const Kernel& kernel, const KernelD
 
     std::vector<KernelResult> results;
 //    KernelResult result(kernel.GetName(), m_ConfigurationManager->GetCurrentConfiguration(id));
-
-    while (!m_ConfigurationManager->IsDataProcessed(id))
-    {
-        KernelResult result(kernel.GetName(), m_ConfigurationManager->GetCurrentConfiguration(id), "");
-        KernelResult multiResult(kernel.GetName(), m_ConfigurationManager->GetCurrentConfiguration(id), ktt::Timestamp::GetTimestamp());
-        int iter = 0;
-        do
-        {
-            result = TuneIteration(kernel, dimensions, KernelRunMode::OfflineTuning, std::vector<BufferOutputDescriptor>{}, false, preciseParams);
-            multiResult.FuseProfilingTimes(result, (iter == 0));
-	    multiResult.TransferPowerData(result);
-            iter++;
-        }
-        while (result.HasRemainingProfilingRuns());
-        if (iter > 1) //do not copy the same result twice
-        {
-            result.CopyProfilingTimes(multiResult);
-            result.TransferPowerData(multiResult);
-        }
-
-        const Nanoseconds searcherOverhead = RunScopeTimer([this, id, &result]()
-        {
-            m_ConfigurationManager->CalculateNextConfiguration(id, result);
-        });
-
-        result.SetSearcherOverhead(searcherOverhead);
-        results.push_back(result);
-
-        if (stopCondition == nullptr)
-        {
-            continue;
-        }
-
-        stopCondition->Update(result);
-        Logger::LogInfo(stopCondition->GetStatusString());
-
-        if (stopCondition->IsFulfilled())
-        {
-            break;
-        }
-    }
-
-    Logger::LogInfo("Ending offline tuning for kernel " + kernel.GetName() + ", total number of tested configurations is "
-        + std::to_string(results.size()));
-    m_KernelRunner.ClearReferenceResult(kernel);
-    return results;
-}
-
-std::vector<KernelResult> TuningRunner::TuneOptions(const Kernel& kernel, const KernelConfiguration& baseConfiguration,
-    const KernelDimensions& dimensions, std::unique_ptr<StopCondition> stopCondition,
-    const std::optional<PreciseMeasurementParameters>& preciseParams)
-{
-    Logger::LogInfo("Starting options tuning for kernel " + kernel.GetName());
-    const auto id = kernel.GetId();
-    m_ConfigurationManager->ClearData(id, true);
-
-    if (!m_ConfigurationManager->HasData(id))
-    {
-        m_ConfigurationManager->InitializeData(kernel, true, baseConfiguration);
-    }
-
-    if (stopCondition != nullptr)
-    {
-        const uint64_t configurationsCount = m_ConfigurationManager->GetTotalConfigurationsCount(id);
-        stopCondition->Initialize(configurationsCount);
-    }
-
-    std::vector<KernelResult> results;
 
     while (!m_ConfigurationManager->IsDataProcessed(id))
     {
@@ -144,7 +89,7 @@ std::vector<KernelResult> TuningRunner::TuneOptions(const Kernel& kernel, const 
         }
     }
 
-    Logger::LogInfo("Ending options tuning for kernel " + kernel.GetName() + ", total number of tested configurations is "
+    Logger::LogInfo("Ending " + tuningMode + " tuning for kernel " + kernel.GetName() + ", total number of tested configurations is "
         + std::to_string(results.size()));
     m_KernelRunner.ClearReferenceResult(kernel);
     return results;

--- a/Source/TuningRunner/TuningRunner.h
+++ b/Source/TuningRunner/TuningRunner.h
@@ -21,10 +21,8 @@ public:
     explicit TuningRunner(KernelRunner& kernelRunner);
 
     std::vector<KernelResult> Tune(const Kernel& kernel, const KernelDimensions& dimensions, std::unique_ptr<StopCondition> stopCondition,
-        const std::optional<PreciseMeasurementParameters>& preciseParams = std::nullopt);
-    std::vector<KernelResult> TuneOptions(const Kernel& kernel, const KernelConfiguration& baseConfiguration,
-        const KernelDimensions& dimensions, std::unique_ptr<StopCondition> stopCondition,
-        const std::optional<PreciseMeasurementParameters>& preciseParams = std::nullopt);
+        const std::optional<PreciseMeasurementParameters>& preciseParams = std::nullopt,
+        const bool tuneOptions = false, const KernelConfiguration& baseConfiguration = {});
     KernelResult TuneIteration(const Kernel& kernel, const KernelDimensions& dimensions, const KernelRunMode mode,
         const std::vector<BufferOutputDescriptor>& output, const bool recomputeReference,
         const std::optional<PreciseMeasurementParameters>& preciseParams = std::nullopt);

--- a/Source/TuningRunner/TuningRunner.h
+++ b/Source/TuningRunner/TuningRunner.h
@@ -22,6 +22,9 @@ public:
 
     std::vector<KernelResult> Tune(const Kernel& kernel, const KernelDimensions& dimensions, std::unique_ptr<StopCondition> stopCondition,
         const std::optional<PreciseMeasurementParameters>& preciseParams = std::nullopt);
+    std::vector<KernelResult> TuneOptions(const Kernel& kernel, const KernelConfiguration& baseConfiguration,
+        const KernelDimensions& dimensions, std::unique_ptr<StopCondition> stopCondition,
+        const std::optional<PreciseMeasurementParameters>& preciseParams = std::nullopt);
     KernelResult TuneIteration(const Kernel& kernel, const KernelDimensions& dimensions, const KernelRunMode mode,
         const std::vector<BufferOutputDescriptor>& output, const bool recomputeReference,
         const std::optional<PreciseMeasurementParameters>& preciseParams = std::nullopt);

--- a/Tutorials/03KernelTuning/KernelTuningOpenCl.cpp
+++ b/Tutorials/03KernelTuning/KernelTuningOpenCl.cpp
@@ -81,9 +81,7 @@ int main(int argc, char** argv)
     // Add new kernel parameter. Specify parameter name and possible values. When kernel is tuned, the parameter value is added
     // to the beginning of kernel source as preprocessor definition. E.g., for value of this parameter equal to 32, it is added
     // as "#define multiply_work_group_size 32".
-    tuner.AddParameter(kernel, "multiply_work_group_size", std::vector<uint64_t>{32, 64});
-    tuner.AddCompilerParameter(kernel, "-cl-mad-enable", {});
-    tuner.AddCompilerParameter(kernel, "-cl-fast-relaxed-math", {}, "KTTSpecialOptionsGroup" );
+    tuner.AddParameter(kernel, "multiply_work_group_size", std::vector<uint64_t>{32, 64, 128, 256});
 
     // In this case, the parameter also affects work-group size. This is specified by adding a thread modifier. ModifierType specifies
     // that parameter affects work-group size of a kernel, ModifierAction specifies that work-group size is multiplied by value of the
@@ -102,15 +100,6 @@ int main(int argc, char** argv)
 
     // Save tuning results to JSON file.
     tuner.SaveResults(results, "TuningOutput", ktt::OutputFormat::JSON);
-
-
-    // just for testing purposes
-    std::cout << "\n=== Tuning Compiler Options Separately ===\n\n";
-
-    auto baseConfiguration = tuner.GetBestConfiguration(kernel);
-    const std::vector<ktt::KernelResult> optionsResults = tuner.TuneOptions(kernel, baseConfiguration);
-
-    std::cout << "Final config: " << tuner.GetBestConfiguration(kernel).GetString() << "\n";
 
     return 0;
 }

--- a/Tutorials/03KernelTuning/KernelTuningOpenCl.cpp
+++ b/Tutorials/03KernelTuning/KernelTuningOpenCl.cpp
@@ -81,7 +81,9 @@ int main(int argc, char** argv)
     // Add new kernel parameter. Specify parameter name and possible values. When kernel is tuned, the parameter value is added
     // to the beginning of kernel source as preprocessor definition. E.g., for value of this parameter equal to 32, it is added
     // as "#define multiply_work_group_size 32".
-    tuner.AddParameter(kernel, "multiply_work_group_size", std::vector<uint64_t>{32, 64, 128, 256});
+    tuner.AddParameter(kernel, "multiply_work_group_size", std::vector<uint64_t>{32, 64});
+    tuner.AddCompilerParameter(kernel, "-cl-mad-enable", {});
+    tuner.AddCompilerParameter(kernel, "-cl-fast-relaxed-math", {}, "KTTSpecialOptionsGroup" );
 
     // In this case, the parameter also affects work-group size. This is specified by adding a thread modifier. ModifierType specifies
     // that parameter affects work-group size of a kernel, ModifierAction specifies that work-group size is multiplied by value of the
@@ -100,6 +102,15 @@ int main(int argc, char** argv)
 
     // Save tuning results to JSON file.
     tuner.SaveResults(results, "TuningOutput", ktt::OutputFormat::JSON);
+
+
+    // just for testing purposes
+    std::cout << "\n=== Tuning Compiler Options Separately ===\n\n";
+
+    auto baseConfiguration = tuner.GetBestConfiguration(kernel);
+    const std::vector<ktt::KernelResult> optionsResults = tuner.TuneOptions(kernel, baseConfiguration);
+
+    std::cout << "Final config: " << tuner.GetBestConfiguration(kernel).GetString() << "\n";
 
     return 0;
 }


### PR DESCRIPTION
I have implemented a baseline for tuning a specific group of compiler options separately after standard tuning.