### PR TITLE
Fix Python bindings for Tune/TuneIteration after PreciseMeasurementParameters addition

### DIFF
--- a/Source/Python/PythonDataHolders.cpp
+++ b/Source/Python/PythonDataHolders.cpp
@@ -139,6 +139,19 @@ void InitializePythonDataHolders(py::module_& module)
         .def("GetOutputDestination", &ktt::BufferOutputDescriptor::GetOutputDestination)
         .def("GetOutputSize", &ktt::BufferOutputDescriptor::GetOutputSize);
 
+    py::class_<ktt::PreciseMeasurementParameters>(module, "PreciseMeasurementParameters")
+        .def(py::init<>())
+        .def(py::init<uint64_t, uint64_t, double, ktt::DurationCalculationMethod>(),
+            py::arg("minTimeMs"),
+            py::arg("maxTimeMs"),
+            py::arg("maxPowerDiff"),
+            py::arg("durationCalculationMethod") = ktt::DurationCalculationMethod::Minimum)
+        .def_readwrite("minTimeMs", &ktt::PreciseMeasurementParameters::minTimeMs)
+        .def_readwrite("maxTimeMs", &ktt::PreciseMeasurementParameters::maxTimeMs)
+        .def_readwrite("maxPowerDiff", &ktt::PreciseMeasurementParameters::maxPowerDiff)
+        .def_readwrite("durationCalculationMethod", &ktt::PreciseMeasurementParameters::durationCalculationMethod)
+        .def("IsValid", &ktt::PreciseMeasurementParameters::IsValid);
+
     py::class_<ktt::KernelCompilationData, py::smart_holder>(module, "KernelCompilationData")
         .def(py::init<>())
         .def_readwrite("m_MaxWorkGroupSize", &ktt::KernelCompilationData::m_MaxWorkGroupSize)

--- a/Source/Python/PythonTuner.cpp
+++ b/Source/Python/PythonTuner.cpp
@@ -495,39 +495,46 @@ void InitializePythonTuner(py::module_& module)
         .def
         (
             "Tune",
-            py::overload_cast<const ktt::KernelId, std::unique_ptr<ktt::StopCondition>>(&ktt::Tuner::Tune),
+            py::overload_cast<const ktt::KernelId, std::unique_ptr<ktt::StopCondition>,
+                const std::optional<ktt::PreciseMeasurementParameters>&>(&ktt::Tuner::Tune),
             py::call_guard<py::gil_scoped_release>(),
             py::arg("id"),
-            py::arg("stopCondition") = nullptr
+            py::arg("stopCondition") = nullptr,
+            py::arg("preciseParams") = std::nullopt
         )
         .def
         (
             "Tune",
-            py::overload_cast<const ktt::KernelId, const ktt::KernelDimensions&, std::unique_ptr<ktt::StopCondition>>(&ktt::Tuner::Tune),
+            py::overload_cast<const ktt::KernelId, const ktt::KernelDimensions&, std::unique_ptr<ktt::StopCondition>,
+                const std::optional<ktt::PreciseMeasurementParameters>&>(&ktt::Tuner::Tune),
             py::call_guard<py::gil_scoped_release>(),
             py::arg("id"),
             py::arg("dimensions"),
-            py::arg("stopCondition") = nullptr
+            py::arg("stopCondition") = nullptr,
+            py::arg("preciseParams") = std::nullopt
         )
         .def
         (
             "TuneIteration",
-            py::overload_cast<const ktt::KernelId, const std::vector<ktt::BufferOutputDescriptor>&, const bool>(&ktt::Tuner::TuneIteration),
+            py::overload_cast<const ktt::KernelId, const std::vector<ktt::BufferOutputDescriptor>&, const bool,
+                const std::optional<ktt::PreciseMeasurementParameters>&>(&ktt::Tuner::TuneIteration),
             py::call_guard<py::gil_scoped_release>(),
             py::arg("id"),
             py::arg("output"),
-            py::arg("recomputeReference") = false
+            py::arg("recomputeReference") = false,
+            py::arg("preciseParams") = std::nullopt
         )
         .def
         (
             "TuneIteration",
             py::overload_cast<const ktt::KernelId, const ktt::KernelDimensions&, const std::vector<ktt::BufferOutputDescriptor>&,
-                const bool>(&ktt::Tuner::TuneIteration),
+                const bool, const std::optional<ktt::PreciseMeasurementParameters>&>(&ktt::Tuner::TuneIteration),
             py::call_guard<py::gil_scoped_release>(),
             py::arg("id"),
             py::arg("dimensions"),
             py::arg("output"),
-            py::arg("recomputeReference") = false
+            py::arg("recomputeReference") = false,
+            py::arg("preciseParams") = std::nullopt
         )
         .def
         (


### PR DESCRIPTION
Commit 31494c8 added `std::optional<PreciseMeasurementParameters>` to `Tuner::Tune` and `Tuner::TuneIteration`, but the pybind11 `overload_cast` calls in `PythonTuner.cpp` were not updated to match the new signatures — building with `--python` fails with template deduction errors.

This patch:
- Adds `PreciseMeasurementParameters` class binding in `PythonDataHolders.cpp` (the `DurationCalculationMethod` enum was already bound in `PythonEnums.cpp`)
- Updates all 4 `overload_cast` calls in `PythonTuner.cpp` to include the new `std::optional<PreciseMeasurementParameters>&` parameter
- Adds `py::arg("preciseParams") = std::nullopt` defaults so existing Python callers are not affected