### PR TITLE
Refactor profiling overhead

### DIFF
--- a/Source/Api/Output/ComputationResult.cpp
+++ b/Source/Api/Output/ComputationResult.cpp
@@ -9,14 +9,16 @@ namespace ktt
 ComputationResult::ComputationResult() :
     m_Duration(InvalidDuration),
     m_Overhead(InvalidDuration),
-    m_CompilationOverhead(InvalidDuration)
+    m_CompilationOverhead(InvalidDuration),
+    m_ProfilingOverhead(InvalidDuration)
 {}
 
 ComputationResult::ComputationResult(const std::string& kernelFunction) :
     m_KernelFunction(kernelFunction),
     m_Duration(InvalidDuration),
     m_Overhead(InvalidDuration),
-    m_CompilationOverhead(InvalidDuration)
+    m_CompilationOverhead(InvalidDuration),
+    m_ProfilingOverhead(InvalidDuration)
 {}
 
 ComputationResult::ComputationResult(const ComputationResult& other) :
@@ -26,6 +28,7 @@ ComputationResult::ComputationResult(const ComputationResult& other) :
     m_Duration(other.m_Duration),
     m_Overhead(other.m_Overhead),
     m_CompilationOverhead(other.m_CompilationOverhead),
+    m_ProfilingOverhead(other.m_ProfilingOverhead),
     m_PowerUsage(other.m_PowerUsage),
     m_Temperature(other.m_Temperature),
     m_SMFrequency(other.m_SMFrequency),
@@ -69,11 +72,12 @@ ComputationResult::ComputationResult(const ComputationResult& other) :
     }
 }
 
-void ComputationResult::SetDurationData(const Nanoseconds duration, const Nanoseconds overhead, const Nanoseconds compilationOverhead)
+void ComputationResult::SetDurationData(const Nanoseconds duration, const Nanoseconds overhead, const Nanoseconds compilationOverhead, const Nanoseconds profilingOverhead)
 {
     m_Duration = duration;
     m_Overhead = overhead;
     m_CompilationOverhead = compilationOverhead;
+    m_ProfilingOverhead = profilingOverhead;
 }
 
 void ComputationResult::SetSizeData(const DimensionVector& globalSize, const DimensionVector& localSize)
@@ -150,6 +154,11 @@ Nanoseconds ComputationResult::GetOverhead() const
 Nanoseconds ComputationResult::GetCompilationOverhead() const
 {
     return m_CompilationOverhead;
+}
+
+Nanoseconds ComputationResult::GetProfilingOverhead() const
+{
+    return m_ProfilingOverhead;
 }
 
 bool ComputationResult::HasCompilationData() const
@@ -294,6 +303,7 @@ ComputationResult& ComputationResult::operator=(const ComputationResult& other)
     m_KernelFunction = other.m_KernelFunction;
     m_Duration = other.m_Duration;
     m_Overhead = other.m_Overhead;
+    m_ProfilingOverhead = other.m_ProfilingOverhead;
     m_GlobalSize = other.m_GlobalSize;
     m_LocalSize = other.m_LocalSize;
     m_PowerUsage = other.m_PowerUsage;

--- a/Source/Api/Output/ComputationResult.cpp
+++ b/Source/Api/Output/ComputationResult.cpp
@@ -10,7 +10,8 @@ ComputationResult::ComputationResult() :
     m_Duration(InvalidDuration),
     m_Overhead(InvalidDuration),
     m_CompilationOverhead(InvalidDuration),
-    m_ProfilingOverhead(InvalidDuration)
+    m_ProfilingOverhead(InvalidDuration),
+    m_PreciseMeasurementOverhead(InvalidDuration)
 {}
 
 ComputationResult::ComputationResult(const std::string& kernelFunction) :
@@ -18,7 +19,8 @@ ComputationResult::ComputationResult(const std::string& kernelFunction) :
     m_Duration(InvalidDuration),
     m_Overhead(InvalidDuration),
     m_CompilationOverhead(InvalidDuration),
-    m_ProfilingOverhead(InvalidDuration)
+    m_ProfilingOverhead(InvalidDuration),
+    m_PreciseMeasurementOverhead(InvalidDuration)
 {}
 
 ComputationResult::ComputationResult(const ComputationResult& other) :
@@ -29,6 +31,7 @@ ComputationResult::ComputationResult(const ComputationResult& other) :
     m_Overhead(other.m_Overhead),
     m_CompilationOverhead(other.m_CompilationOverhead),
     m_ProfilingOverhead(other.m_ProfilingOverhead),
+    m_PreciseMeasurementOverhead(other.m_PreciseMeasurementOverhead),
     m_PowerUsage(other.m_PowerUsage),
     m_Temperature(other.m_Temperature),
     m_SMFrequency(other.m_SMFrequency),
@@ -72,12 +75,13 @@ ComputationResult::ComputationResult(const ComputationResult& other) :
     }
 }
 
-void ComputationResult::SetDurationData(const Nanoseconds duration, const Nanoseconds overhead, const Nanoseconds compilationOverhead, const Nanoseconds profilingOverhead)
+void ComputationResult::SetDurationData(const Nanoseconds duration, const Nanoseconds overhead, const Nanoseconds compilationOverhead, const Nanoseconds profilingOverhead, const Nanoseconds preciseMeasurementOverhead)
 {
     m_Duration = duration;
     m_Overhead = overhead;
     m_CompilationOverhead = compilationOverhead;
     m_ProfilingOverhead = profilingOverhead;
+    m_PreciseMeasurementOverhead = preciseMeasurementOverhead;
 }
 
 void ComputationResult::SetSizeData(const DimensionVector& globalSize, const DimensionVector& localSize)
@@ -159,6 +163,11 @@ Nanoseconds ComputationResult::GetCompilationOverhead() const
 Nanoseconds ComputationResult::GetProfilingOverhead() const
 {
     return m_ProfilingOverhead;
+}
+
+Nanoseconds ComputationResult::GetPreciseMeasurementOverhead() const
+{
+    return m_PreciseMeasurementOverhead;
 }
 
 bool ComputationResult::HasCompilationData() const
@@ -304,6 +313,7 @@ ComputationResult& ComputationResult::operator=(const ComputationResult& other)
     m_Duration = other.m_Duration;
     m_Overhead = other.m_Overhead;
     m_ProfilingOverhead = other.m_ProfilingOverhead;
+    m_PreciseMeasurementOverhead = other.m_PreciseMeasurementOverhead;
     m_GlobalSize = other.m_GlobalSize;
     m_LocalSize = other.m_LocalSize;
     m_PowerUsage = other.m_PowerUsage;

--- a/Source/Api/Output/ComputationResult.h
+++ b/Source/Api/Output/ComputationResult.h
@@ -47,8 +47,9 @@ public:
       * @param overhead Overhead related to kernel launch such as kernel function compilation.
       * @param compilationOverhead Overhead related purely to kernel function compilation.
       * @param profilingOverhead Overhead related to profiling data collection.
+      * @param preciseMeasurementOverhead Overhead of the precise multi-run measurement loop.
       */
-    void SetDurationData(const Nanoseconds duration, const Nanoseconds overhead, const Nanoseconds compilationOverhead, const Nanoseconds profilingOverhead = 0);
+    void SetDurationData(const Nanoseconds duration, const Nanoseconds overhead, const Nanoseconds compilationOverhead, const Nanoseconds profilingOverhead = 0, const Nanoseconds preciseMeasurementOverhead = 0);
 
     /** @fn void SetSizeData(const DimensionVector& globalSize, const DimensionVector& localSize)
       * Fills thread size data for the result.
@@ -146,6 +147,12 @@ public:
         * @return Profiling overhead.
         */
     Nanoseconds GetProfilingOverhead() const;
+
+    /** @fn Nanoseconds GetPreciseMeasurementOverhead() const
+      * Returns overhead of the precise multi-run measurement loop.
+      * @return Precise measurement overhead.
+      */
+    Nanoseconds GetPreciseMeasurementOverhead() const;
 
     /** @fn bool HasCompilationData() const
       * Checks whether result contains valid compilation data.
@@ -270,6 +277,7 @@ private:
     Nanoseconds m_Overhead;
     Nanoseconds m_CompilationOverhead;
     Nanoseconds m_ProfilingOverhead;
+    Nanoseconds m_PreciseMeasurementOverhead;
     std::unique_ptr<KernelCompilationData> m_CompilationData;
     std::unique_ptr<KernelProfilingData> m_ProfilingData;
     std::optional<uint32_t> m_PowerUsage;

--- a/Source/Api/Output/ComputationResult.h
+++ b/Source/Api/Output/ComputationResult.h
@@ -46,8 +46,9 @@ public:
       * @param duration Raw kernel duration, usually reported by the underlying compute API.
       * @param overhead Overhead related to kernel launch such as kernel function compilation.
       * @param compilationOverhead Overhead related purely to kernel function compilation.
+      * @param profilingOverhead Overhead related to profiling data collection.
       */
-    void SetDurationData(const Nanoseconds duration, const Nanoseconds overhead, const Nanoseconds compilationOverhead);
+    void SetDurationData(const Nanoseconds duration, const Nanoseconds overhead, const Nanoseconds compilationOverhead, const Nanoseconds profilingOverhead = 0);
 
     /** @fn void SetSizeData(const DimensionVector& globalSize, const DimensionVector& localSize)
       * Fills thread size data for the result.
@@ -139,6 +140,12 @@ public:
       * @return Kernel overhead.
       */
     Nanoseconds GetCompilationOverhead() const;
+
+      /** @fn Nanoseconds GetProfilingOverhead() const
+        * Returns overhead related to profiling data collection.
+        * @return Profiling overhead.
+        */
+    Nanoseconds GetProfilingOverhead() const;
 
     /** @fn bool HasCompilationData() const
       * Checks whether result contains valid compilation data.
@@ -262,6 +269,7 @@ private:
     Nanoseconds m_Duration;
     Nanoseconds m_Overhead;
     Nanoseconds m_CompilationOverhead;
+    Nanoseconds m_ProfilingOverhead;
     std::unique_ptr<KernelCompilationData> m_CompilationData;
     std::unique_ptr<KernelProfilingData> m_ProfilingData;
     std::optional<uint32_t> m_PowerUsage;

--- a/Source/Api/Output/KernelResult.cpp
+++ b/Source/Api/Output/KernelResult.cpp
@@ -17,6 +17,7 @@ KernelResult::KernelResult() :
     m_CompilationOverhead(InvalidDuration),
     m_KernelOverhead(InvalidDuration),
     m_KernelOverheadFirstPass(InvalidDuration),
+    m_ExtraDurationFirstPass(InvalidDuration),
     m_Status(ResultStatus::ComputationFailed)
 {}
 
@@ -35,6 +36,7 @@ KernelResult::KernelResult(const std::string& kernelName, const KernelConfigurat
     m_CompilationOverhead(0),
     m_KernelOverhead(0),
     m_KernelOverheadFirstPass(0),
+    m_ExtraDurationFirstPass(0),
     m_Status(ResultStatus::ComputationFailed)
 {}
 
@@ -55,6 +57,7 @@ KernelResult::KernelResult(const std::string& kernelName, const KernelConfigurat
     m_CompilationOverhead(0),
     m_KernelOverhead(0),
     m_KernelOverheadFirstPass(0),
+    m_ExtraDurationFirstPass(0),
     m_Status(ResultStatus::Ok)
 {}
 
@@ -178,6 +181,11 @@ Nanoseconds KernelResult::GetExtraDuration() const
     return m_ExtraDuration;
 }
 
+Nanoseconds KernelResult::GetExtraDurationFirstPass() const
+{
+    return m_ExtraDurationFirstPass;
+}
+
 Nanoseconds KernelResult::GetExtraOverhead() const
 {
     return m_DataMovementOverhead;
@@ -287,7 +295,6 @@ void KernelResult::FuseProfilingTimes(const KernelResult& previousResult, bool f
     m_CompilationOverhead += previousResult.GetCompilationOverheadFromCompResults();
     m_CompilationOverhead += previousResult.GetCompilationOverhead();
 
-    m_ExtraDuration += previousResult.GetExtraDuration();
     m_DataMovementOverhead += previousResult.GetDataMovementOverhead();
     m_ValidationOverhead += previousResult.GetValidationOverhead();
     m_SearcherOverhead += previousResult.GetSearcherOverhead();
@@ -300,8 +307,15 @@ void KernelResult::FuseProfilingTimes(const KernelResult& previousResult, bool f
 
     if (first)
     {
+        // we want to preserve some data from the first pass
+        //these include 
+        // first, the kernel overhead of the first pass, which is needed for correct total overhead calculation and for correct output of the final results
         m_KernelOverheadFirstPass = m_KernelOverhead;
-        // we want to preserve the original results of the first pass, as these are done without profiling and thus contain the actual duration of the kernel execution
+
+        // second, the extra duration of the first pass, which is needed for correct total duration calculation and correct reporting of the final results
+        m_ExtraDurationFirstPass = previousResult.GetExtraDuration();
+
+        // third, we want to preserve the original results of the first pass, as these are done without profiling and thus contain the actual duration of the kernel execution
         //moreover, these also contain the actual compilation and kernel overhead that contains actual compilation, not just loading cached version
         // these durations (kernel, compilation and kernel overhead) are then copied into the result of the final pass, after accounting for all the overheads, especially the profiling related ones
         m_Results = previousResult.GetResults();
@@ -310,12 +324,13 @@ void KernelResult::FuseProfilingTimes(const KernelResult& previousResult, bool f
     if (!first)
     {
         m_ProfilingRunsOverhead += previousResult.GetKernelDuration();
+        m_ProfilingRunsOverhead += previousResult.GetExtraDuration();
         m_ProfilingRunsOverhead += previousResult.GetKernelOverheadFromCompResults();
         m_ProfilingRunsOverhead += previousResult.GetKernelOverhead();
         m_ProfilingRunsOverhead += previousResult.GetProfilingRunsOverhead();
 
         m_ProfilingOverhead += previousResult.GetDataMovementOverhead();
-        m_ProfilingOverhead += previousResult.GetExtraDuration();
+        m_ProfilingOverhead += previousResult.GetValidationOverhead();
     }
 }
 
@@ -328,7 +343,7 @@ void KernelResult::CopyProfilingTimes(const KernelResult& originalResult)
             originalResult.m_Results[i].GetDuration(),
             originalResult.m_Results[i].GetOverhead(),
             originalResult.m_Results[i].GetCompilationOverhead(),
-            m_Results[i].GetProfilingOverhead()); // preserve last-pass value
+            m_Results[i].GetProfilingOverhead()); // preserve last-pass value    
     }
     m_ProfilingRunsOverhead = originalResult.GetProfilingRunsOverhead();
     m_ProfilingOverhead = originalResult.GetProfilingOverhead();
@@ -336,7 +351,8 @@ void KernelResult::CopyProfilingTimes(const KernelResult& originalResult)
     m_CompilationOverhead = originalResult.GetCompilationOverhead();
     m_KernelOverhead = originalResult.GetKernelOverhead();
     m_KernelOverheadFirstPass = originalResult.GetKernelOverheadFirstPass();
-    m_ExtraDuration = originalResult.GetExtraDuration();
+    m_ExtraDuration = originalResult.GetExtraDurationFirstPass();
+    m_ExtraDurationFirstPass = originalResult.GetExtraDurationFirstPass();
     m_DataMovementOverhead = originalResult.GetDataMovementOverhead();
     m_ValidationOverhead = originalResult.GetValidationOverhead();
     m_SearcherOverhead = originalResult.GetSearcherOverhead();

--- a/Source/Api/Output/KernelResult.cpp
+++ b/Source/Api/Output/KernelResult.cpp
@@ -17,7 +17,6 @@ KernelResult::KernelResult() :
     m_CompilationOverhead(InvalidDuration),
     m_KernelOverhead(InvalidDuration),
     m_KernelOverheadFirstPass(InvalidDuration),
-    m_TotalOverhead(InvalidDuration),
     m_Status(ResultStatus::ComputationFailed)
 {}
 
@@ -36,7 +35,6 @@ KernelResult::KernelResult(const std::string& kernelName, const KernelConfigurat
     m_CompilationOverhead(0),
     m_KernelOverhead(0),
     m_KernelOverheadFirstPass(0),
-    m_TotalOverhead(0),
     m_Status(ResultStatus::ComputationFailed)
 {}
 
@@ -57,7 +55,6 @@ KernelResult::KernelResult(const std::string& kernelName, const KernelConfigurat
     m_CompilationOverhead(0),
     m_KernelOverhead(0),
     m_KernelOverheadFirstPass(0),
-    m_TotalOverhead(0),
     m_Status(ResultStatus::Ok)
 {}
 
@@ -249,24 +246,19 @@ Nanoseconds KernelResult::GetTotalDuration() const
 
 Nanoseconds KernelResult::GetTotalOverhead() const
 {
-    if (m_TotalOverhead != InvalidDuration && m_TotalOverhead > 0)
-    {
-        return m_TotalOverhead;
-    }
-
     Nanoseconds overhead = m_DataMovementOverhead + m_ValidationOverhead + m_SearcherOverhead + m_FailedKernelOverhead;
 
-    if (m_ProfilingRunsOverhead == 0) //without profiling
+    //either without profiling or the first pass of profiling
+    overhead += m_KernelOverheadFirstPass;
+
+    if (m_ProfilingRunsOverhead > 0) //with profiling
     {
-        overhead += GetKernelOverheadFromCompResults() + GetKernelOverhead(); // kernel overhead of a single pass, that includes compilation overhead
-    }
-    else //profiling
-    { 
-        overhead += GetProfilingOverheadFromCompResults() + m_ProfilingRunsOverhead; 
+        overhead += m_ProfilingInfrastructureOverhead + m_ProfilingRunsOverhead; 
         // GetProfilingInfrastructureOverhead() adds overhead of profiling infrastructure, but without data movement and extra duration
         //profilingRunsOverhead includes kernel overhead and kernel duration of extra passes
 
     }
+
     return overhead;
 }
 
@@ -294,6 +286,7 @@ void KernelResult::FuseProfilingTimes(const KernelResult& previousResult, bool f
     m_KernelOverhead += previousResult.GetKernelOverhead();
     m_CompilationOverhead += previousResult.GetCompilationOverheadFromCompResults();
     m_CompilationOverhead += previousResult.GetCompilationOverhead();
+
     m_ExtraDuration += previousResult.GetExtraDuration();
     m_DataMovementOverhead += previousResult.GetDataMovementOverhead();
     m_ValidationOverhead += previousResult.GetValidationOverhead();
@@ -304,7 +297,6 @@ void KernelResult::FuseProfilingTimes(const KernelResult& previousResult, bool f
     m_ProfilingOverhead += previousResult.GetProfilingOverhead();
     m_ProfilingInfrastructureOverhead += previousResult.GetProfilingOverheadFromCompResults();
     m_ProfilingInfrastructureOverhead += previousResult.GetProfilingInfrastructureOverhead();
-
 
     if (first)
     {
@@ -325,7 +317,6 @@ void KernelResult::FuseProfilingTimes(const KernelResult& previousResult, bool f
         m_ProfilingOverhead += previousResult.GetDataMovementOverhead();
         m_ProfilingOverhead += previousResult.GetExtraDuration();
     }
-
 }
 
 void KernelResult::CopyProfilingTimes(const KernelResult& originalResult)
@@ -350,7 +341,6 @@ void KernelResult::CopyProfilingTimes(const KernelResult& originalResult)
     m_ValidationOverhead = originalResult.GetValidationOverhead();
     m_SearcherOverhead = originalResult.GetSearcherOverhead();
     m_FailedKernelOverhead = originalResult.GetFailedKernelOverhead();
-    m_TotalOverhead = originalResult.GetTotalOverhead();
 }
 
 void KernelResult::TransferPowerData(const KernelResult& previousResult) 

--- a/Source/Api/Output/KernelResult.cpp
+++ b/Source/Api/Output/KernelResult.cpp
@@ -309,6 +309,10 @@ void KernelResult::FuseProfilingTimes(const KernelResult& previousResult, bool f
     if (first)
     {
         m_KernelOverheadFirstPass = m_KernelOverhead;
+        // we want to preserve the original results of the first pass, as these are done without profiling and thus contain the actual duration of the kernel execution
+        //moreover, these also contain the actual compilation and kernel overhead that contains actual compilation, not just loading cached version
+        // these durations (kernel, compilation and kernel overhead) are then copied into the result of the final pass, after accounting for all the overheads, especially the profiling related ones
+        m_Results = previousResult.GetResults();
     }
 
     if (!first)
@@ -326,6 +330,15 @@ void KernelResult::FuseProfilingTimes(const KernelResult& previousResult, bool f
 
 void KernelResult::CopyProfilingTimes(const KernelResult& originalResult)
 {
+    //copy kernel duration, kernel overhead and compilation overhead from the first pass of the kernel into the results of the final pass
+    //this ensures that the output files contain the actual kernel duration and compilation overhead
+    for (size_t i = 0; i < m_Results.size(); i++) {
+        m_Results[i].SetDurationData(
+            originalResult.m_Results[i].GetDuration(),
+            originalResult.m_Results[i].GetOverhead(),
+            originalResult.m_Results[i].GetCompilationOverhead(),
+            m_Results[i].GetProfilingOverhead()); // preserve last-pass value
+    }
     m_ProfilingRunsOverhead = originalResult.GetProfilingRunsOverhead();
     m_ProfilingOverhead = originalResult.GetProfilingOverhead();
     m_ProfilingInfrastructureOverhead = originalResult.GetProfilingInfrastructureOverhead();

--- a/Source/Api/Output/KernelResult.cpp
+++ b/Source/Api/Output/KernelResult.cpp
@@ -1,4 +1,5 @@
 #include <Api/Output/KernelResult.h>
+#include "KernelResult.h"
 
 namespace ktt
 {
@@ -12,7 +13,11 @@ KernelResult::KernelResult() :
     m_FailedKernelOverhead(InvalidDuration),
     m_ProfilingRunsOverhead(InvalidDuration),
     m_ProfilingOverhead(InvalidDuration),
+    m_ProfilingInfrastructureOverhead(InvalidDuration),
     m_CompilationOverhead(InvalidDuration),
+    m_KernelOverhead(InvalidDuration),
+    m_KernelOverheadFirstPass(InvalidDuration),
+    m_TotalOverhead(InvalidDuration),
     m_Status(ResultStatus::ComputationFailed)
 {}
 
@@ -27,7 +32,11 @@ KernelResult::KernelResult(const std::string& kernelName, const KernelConfigurat
     m_FailedKernelOverhead(0),
     m_ProfilingRunsOverhead(0),
     m_ProfilingOverhead(0),
+    m_ProfilingInfrastructureOverhead(0),
     m_CompilationOverhead(0),
+    m_KernelOverhead(0),
+    m_KernelOverheadFirstPass(0),
+    m_TotalOverhead(0),
     m_Status(ResultStatus::ComputationFailed)
 {}
 
@@ -44,7 +53,11 @@ KernelResult::KernelResult(const std::string& kernelName, const KernelConfigurat
     m_FailedKernelOverhead(0),
     m_ProfilingRunsOverhead(0),
     m_ProfilingOverhead(0),
+    m_ProfilingInfrastructureOverhead(0),
     m_CompilationOverhead(0),
+    m_KernelOverhead(0),
+    m_KernelOverheadFirstPass(0),
+    m_TotalOverhead(0),
     m_Status(ResultStatus::Ok)
 {}
 
@@ -129,7 +142,7 @@ Nanoseconds KernelResult::GetKernelDuration() const
     return duration;
 }
 
-Nanoseconds KernelResult::GetKernelOverhead() const
+Nanoseconds KernelResult::GetKernelOverheadFromCompResults() const
 {
     Nanoseconds overhead = 0;
 
@@ -141,7 +154,17 @@ Nanoseconds KernelResult::GetKernelOverhead() const
     return overhead;
 }
 
-Nanoseconds KernelResult::GetKernelCompilationOverhead() const
+Nanoseconds KernelResult::GetKernelOverhead() const
+{
+    return m_KernelOverhead;
+}
+
+Nanoseconds KernelResult::GetKernelOverheadFirstPass() const
+{
+    return m_KernelOverheadFirstPass;
+}
+
+Nanoseconds KernelResult::GetCompilationOverheadFromCompResults() const
 {
     Nanoseconds overhead = 0;
 
@@ -150,7 +173,7 @@ Nanoseconds KernelResult::GetKernelCompilationOverhead() const
         overhead += result.GetCompilationOverhead();
     }
 
-    return overhead + m_CompilationOverhead;
+    return overhead;
 }
 
 Nanoseconds KernelResult::GetExtraDuration() const
@@ -188,6 +211,21 @@ Nanoseconds KernelResult::GetProfilingRunsOverhead() const
     return m_ProfilingRunsOverhead;
 }
 
+Nanoseconds KernelResult::GetProfilingOverheadFromCompResults() const
+{
+    Nanoseconds overhead = 0;
+    for (const auto &result : m_Results)
+    {
+        overhead += result.GetProfilingOverhead();
+    }
+    return overhead;
+}
+
+Nanoseconds KernelResult::GetProfilingInfrastructureOverhead() const
+{
+    return m_ProfilingInfrastructureOverhead;
+}
+
 Nanoseconds KernelResult::GetProfilingOverhead() const
 {
     return m_ProfilingOverhead;
@@ -200,7 +238,7 @@ Nanoseconds KernelResult::GetProfilingTotalOverhead() const
 
 Nanoseconds KernelResult::GetCompilationOverhead() const
 {
-    return GetKernelCompilationOverhead();
+    return m_CompilationOverhead;
 }
 
 Nanoseconds KernelResult::GetTotalDuration() const
@@ -211,9 +249,24 @@ Nanoseconds KernelResult::GetTotalDuration() const
 
 Nanoseconds KernelResult::GetTotalOverhead() const
 {
-    Nanoseconds overhead = m_DataMovementOverhead + m_ValidationOverhead + m_SearcherOverhead + /*GetKernelOverhead() +*/ m_FailedKernelOverhead + m_ProfilingRunsOverhead + m_CompilationOverhead;
-    if (m_ProfilingRunsOverhead == 0)
-        overhead += GetKernelOverhead(); //in case there is no profiling, include also actual kernel overhead (was not fused)
+    if (m_TotalOverhead != InvalidDuration && m_TotalOverhead > 0)
+    {
+        return m_TotalOverhead;
+    }
+
+    Nanoseconds overhead = m_DataMovementOverhead + m_ValidationOverhead + m_SearcherOverhead + m_FailedKernelOverhead;
+
+    if (m_ProfilingRunsOverhead == 0) //without profiling
+    {
+        overhead += GetKernelOverheadFromCompResults() + GetKernelOverhead(); // kernel overhead of a single pass, that includes compilation overhead
+    }
+    else //profiling
+    { 
+        overhead += GetProfilingOverheadFromCompResults() + m_ProfilingRunsOverhead; 
+        // GetProfilingInfrastructureOverhead() adds overhead of profiling infrastructure, but without data movement and extra duration
+        //profilingRunsOverhead includes kernel overhead and kernel duration of extra passes
+
+    }
     return overhead;
 }
 
@@ -237,32 +290,54 @@ bool KernelResult::HasRemainingProfilingRuns() const
 
 void KernelResult::FuseProfilingTimes(const KernelResult& previousResult, bool first)
 {
-    if (! first) {
-        m_ProfilingRunsOverhead += previousResult.GetKernelDuration();
-        m_ProfilingRunsOverhead += previousResult.GetKernelOverhead();
-        m_ProfilingRunsOverhead += previousResult.GetProfilingRunsOverhead();
-        m_ProfilingOverhead += previousResult.GetDataMovementOverhead();
-        m_ProfilingOverhead += previousResult.GetExtraDuration();
-        m_ProfilingOverhead += previousResult.GetProfilingOverhead();
-    }
+    m_KernelOverhead += previousResult.GetKernelOverheadFromCompResults();
+    m_KernelOverhead += previousResult.GetKernelOverhead();
+    m_CompilationOverhead += previousResult.GetCompilationOverheadFromCompResults();
     m_CompilationOverhead += previousResult.GetCompilationOverhead();
     m_ExtraDuration += previousResult.GetExtraDuration();
     m_DataMovementOverhead += previousResult.GetDataMovementOverhead();
     m_ValidationOverhead += previousResult.GetValidationOverhead();
     m_SearcherOverhead += previousResult.GetSearcherOverhead();
     m_FailedKernelOverhead += previousResult.GetFailedKernelOverhead();
+
+    m_ProfilingOverhead += previousResult.GetProfilingOverheadFromCompResults();
+    m_ProfilingOverhead += previousResult.GetProfilingOverhead();
+    m_ProfilingInfrastructureOverhead += previousResult.GetProfilingOverheadFromCompResults();
+    m_ProfilingInfrastructureOverhead += previousResult.GetProfilingInfrastructureOverhead();
+
+
+    if (first)
+    {
+        m_KernelOverheadFirstPass = m_KernelOverhead;
+    }
+
+    if (!first)
+    {
+        m_ProfilingRunsOverhead += previousResult.GetKernelDuration();
+        m_ProfilingRunsOverhead += previousResult.GetKernelOverheadFromCompResults();
+        m_ProfilingRunsOverhead += previousResult.GetKernelOverhead();
+        m_ProfilingRunsOverhead += previousResult.GetProfilingRunsOverhead();
+
+        m_ProfilingOverhead += previousResult.GetDataMovementOverhead();
+        m_ProfilingOverhead += previousResult.GetExtraDuration();
+    }
+
 }
 
 void KernelResult::CopyProfilingTimes(const KernelResult& originalResult)
 {
     m_ProfilingRunsOverhead = originalResult.GetProfilingRunsOverhead();
     m_ProfilingOverhead = originalResult.GetProfilingOverhead();
+    m_ProfilingInfrastructureOverhead = originalResult.GetProfilingInfrastructureOverhead();
     m_CompilationOverhead = originalResult.GetCompilationOverhead();
+    m_KernelOverhead = originalResult.GetKernelOverhead();
+    m_KernelOverheadFirstPass = originalResult.GetKernelOverheadFirstPass();
     m_ExtraDuration = originalResult.GetExtraDuration();
     m_DataMovementOverhead = originalResult.GetDataMovementOverhead();
     m_ValidationOverhead = originalResult.GetValidationOverhead();
     m_SearcherOverhead = originalResult.GetSearcherOverhead();
     m_FailedKernelOverhead = originalResult.GetFailedKernelOverhead();
+    m_TotalOverhead = originalResult.GetTotalOverhead();
 }
 
 void KernelResult::TransferPowerData(const KernelResult& previousResult) 

--- a/Source/Api/Output/KernelResult.cpp
+++ b/Source/Api/Output/KernelResult.cpp
@@ -14,6 +14,7 @@ KernelResult::KernelResult() :
     m_ProfilingRunsOverhead(InvalidDuration),
     m_ProfilingOverhead(InvalidDuration),
     m_ProfilingInfrastructureOverhead(InvalidDuration),
+    m_PreciseMeasurementOverhead(InvalidDuration),
     m_CompilationOverhead(InvalidDuration),
     m_KernelOverhead(InvalidDuration),
     m_KernelOverheadFirstPass(InvalidDuration),
@@ -33,6 +34,7 @@ KernelResult::KernelResult(const std::string& kernelName, const KernelConfigurat
     m_ProfilingRunsOverhead(0),
     m_ProfilingOverhead(0),
     m_ProfilingInfrastructureOverhead(0),
+    m_PreciseMeasurementOverhead(0),
     m_CompilationOverhead(0),
     m_KernelOverhead(0),
     m_KernelOverheadFirstPass(0),
@@ -54,6 +56,7 @@ KernelResult::KernelResult(const std::string& kernelName, const KernelConfigurat
     m_ProfilingRunsOverhead(0),
     m_ProfilingOverhead(0),
     m_ProfilingInfrastructureOverhead(0),
+    m_PreciseMeasurementOverhead(0),
     m_CompilationOverhead(0),
     m_KernelOverhead(0),
     m_KernelOverheadFirstPass(0),
@@ -104,6 +107,11 @@ void KernelResult::SetProfilingRunsOverhead(const Nanoseconds overhead)
 void KernelResult::SetProfilingOverhead(const Nanoseconds overhead)
 {
     m_ProfilingOverhead = overhead;
+}
+
+void KernelResult::SetPreciseMeasurementOverhead(const Nanoseconds overhead)
+{
+    m_PreciseMeasurementOverhead = overhead;
 }
 
 const std::string& KernelResult::GetKernelName() const
@@ -226,6 +234,21 @@ Nanoseconds KernelResult::GetProfilingOverheadFromCompResults() const
     return overhead;
 }
 
+Nanoseconds KernelResult::GetPreciseMeasurementOverheadFromCompResults() const
+{
+    Nanoseconds overhead = 0;
+    for (const auto& result : m_Results)
+    {
+        overhead += result.GetPreciseMeasurementOverhead();
+    }
+    // if precise measurement overhead is present, the kernel duration ("official" result) is included in it, so we need to subtract it to avoid double counting
+    if (overhead > 0)
+    {
+        overhead -= GetKernelDuration();
+    }
+    return overhead;
+}
+
 Nanoseconds KernelResult::GetProfilingInfrastructureOverhead() const
 {
     return m_ProfilingInfrastructureOverhead;
@@ -234,6 +257,11 @@ Nanoseconds KernelResult::GetProfilingInfrastructureOverhead() const
 Nanoseconds KernelResult::GetProfilingOverhead() const
 {
     return m_ProfilingOverhead;
+}
+
+Nanoseconds KernelResult::GetPreciseMeasurementOverhead() const
+{
+    return m_PreciseMeasurementOverhead;
 }
 
 Nanoseconds KernelResult::GetProfilingTotalOverhead() const
@@ -254,7 +282,8 @@ Nanoseconds KernelResult::GetTotalDuration() const
 
 Nanoseconds KernelResult::GetTotalOverhead() const
 {
-    Nanoseconds overhead = m_DataMovementOverhead + m_ValidationOverhead + m_SearcherOverhead + m_FailedKernelOverhead;
+    Nanoseconds overhead = m_DataMovementOverhead + m_ValidationOverhead + m_SearcherOverhead
+                           + m_FailedKernelOverhead + m_PreciseMeasurementOverhead;
 
     //either without profiling or the first pass of profiling
     overhead += m_KernelOverheadFirstPass;
@@ -304,6 +333,8 @@ void KernelResult::FuseProfilingTimes(const KernelResult& previousResult, bool f
     m_ProfilingOverhead += previousResult.GetProfilingOverhead();
     m_ProfilingInfrastructureOverhead += previousResult.GetProfilingOverheadFromCompResults();
     m_ProfilingInfrastructureOverhead += previousResult.GetProfilingInfrastructureOverhead();
+    m_PreciseMeasurementOverhead += previousResult.GetPreciseMeasurementOverheadFromCompResults();
+    m_PreciseMeasurementOverhead += previousResult.GetPreciseMeasurementOverhead();
 
     if (first)
     {
@@ -357,6 +388,7 @@ void KernelResult::CopyProfilingTimes(const KernelResult& originalResult)
     m_ValidationOverhead = originalResult.GetValidationOverhead();
     m_SearcherOverhead = originalResult.GetSearcherOverhead();
     m_FailedKernelOverhead = originalResult.GetFailedKernelOverhead();
+    m_PreciseMeasurementOverhead = originalResult.GetPreciseMeasurementOverhead();
 }
 
 void KernelResult::TransferPowerData(const KernelResult& previousResult) 

--- a/Source/Api/Output/KernelResult.h
+++ b/Source/Api/Output/KernelResult.h
@@ -98,6 +98,12 @@ public:
       */
     void SetProfilingOverhead(const Nanoseconds overhead);
 
+    /** @fn void SetPreciseMeasurementOverhead(const Nanoseconds overhead)
+      * Sets duration of the precise multi-run measurement loop.
+      * @param overhead Duration of the precise multi-run measurement loop.
+      */
+    void SetPreciseMeasurementOverhead(const Nanoseconds overhead);
+
     /** @fn const std::string& GetKernelName() const
       * Returns name of a kernel tied to the result.
       * @return Name of a kernel tied to the result.
@@ -220,11 +226,23 @@ public:
       */
     Nanoseconds GetProfilingOverheadFromCompResults() const;
 
+    /** @fn Nanoseconds GetPreciseMeasurementOverheadFromCompResults() const
+      * Retrieves the sum of precise multi-run measurement overhead from the partial results.
+      * @return Sum of precise measurement overhead across all partial results.
+      */
+    Nanoseconds GetPreciseMeasurementOverheadFromCompResults() const;
+
     /** @fn Nanoseconds GetProfilingOverhead() const
       * Retrieves duration of all non-kernel operations performed during collection performance counters (e.g., CUPTI infrastructure and data movements for extra kernel runs) for all profiling runs.
       * @return Duration operations different than kernel execution needed to collect performance counters.
       */
     Nanoseconds GetProfilingOverhead() const;
+
+    /** @fn Nanoseconds GetPreciseMeasurementOverhead() const
+      * Retrieves duration of the precise multi-run measurement loop.
+      * @return Duration of the precise multi-run measurement loop.
+      */
+    Nanoseconds GetPreciseMeasurementOverhead() const;
 
     /** @fn Nanoseconds GetProfilingTotalOverhead() const
       * Retrieves duration and overhead of all operations needed to collect performance counters.
@@ -246,8 +264,10 @@ public:
     Nanoseconds GetTotalDuration() const;
 
     /** @fn Nanoseconds GetTotalOverhead() const
-      * Retrieves the sum of kernel overhead, data movement, validation, searcher and profiling related overhead.
-      * @return The sum of kernel overhead, data movement, validation, searcher and profiling related overhead.
+      * Retrieves the sum of kernel overhead, data movement, validation, searcher, precise
+      * measurement and profiling related overhead.
+      * @return The sum of kernel overhead, data movement, validation, searcher, precise
+      * measurement and profiling related overhead.
       */
     Nanoseconds GetTotalOverhead() const;
 
@@ -296,6 +316,7 @@ private:
     Nanoseconds m_ProfilingRunsOverhead; //overhead of all profiling runs, including kernel overhead and kernel duration and extra duration of extra passes
     Nanoseconds m_ProfilingOverhead; //overhead of profiling infrastructure, with data movement and validation, for all profiling passes
     Nanoseconds m_ProfilingInfrastructureOverhead; //overhead of profiling infrastructure, but without data movement and extra duration, for all profiling passes
+    Nanoseconds m_PreciseMeasurementOverhead; //overhead of the precise multi-run measurement loop, including all kernel executions performed within the loop
     Nanoseconds m_CompilationOverhead;
     Nanoseconds m_KernelOverhead;
     Nanoseconds m_KernelOverheadFirstPass; //kernel overhead of the first pass (i.e. full compilation and run without profiling)

--- a/Source/Api/Output/KernelResult.h
+++ b/Source/Api/Output/KernelResult.h
@@ -240,16 +240,10 @@ public:
     Nanoseconds GetTotalDuration() const;
 
     /** @fn Nanoseconds GetTotalOverhead() const
-      * Retrieves the sum of kernel, data movement, validation and searcher overhead.
-      * @return The sum of kernel, data movement, validation and searcher overhead.
+      * Retrieves the sum of kernel overhead, data movement, validation, searcher and profiling related overhead.
+      * @return The sum of kernel overhead, data movement, validation, searcher and profiling related overhead.
       */
     Nanoseconds GetTotalOverhead() const;
-
-    /** @fn Nanoseconds ComputeTotalOverhead() const
-      * Computes the total overhead by summing up all individual overhead components.
-      * @return Total overhead.
-      */
-    Nanoseconds ComputeTotalOverhead() const;
 
     /** @fn bool IsValid() const
       * Checks whether kernel result is valid. I.e., its status has value Ok.
@@ -293,13 +287,12 @@ private:
     Nanoseconds m_ValidationOverhead;
     Nanoseconds m_SearcherOverhead;
     Nanoseconds m_FailedKernelOverhead;
-    Nanoseconds m_ProfilingRunsOverhead;
-    Nanoseconds m_ProfilingOverhead;
-    Nanoseconds m_ProfilingInfrastructureOverhead;
+    Nanoseconds m_ProfilingRunsOverhead; //overhead of all profiling runs, including kernel overhead and kernel duration of extra passes
+    Nanoseconds m_ProfilingOverhead; //overhead of profiling infrastructure, with data movement and extra duration, for all profiling passes
+    Nanoseconds m_ProfilingInfrastructureOverhead; //overhead of profiling infrastructure, but without data movement and extra duration, for all profiling passes
     Nanoseconds m_CompilationOverhead;
     Nanoseconds m_KernelOverhead;
-    Nanoseconds m_KernelOverheadFirstPass;
-    Nanoseconds m_TotalOverhead;
+    Nanoseconds m_KernelOverheadFirstPass; //kernel overhead of the first pass (i.e. full compilation and run without profiling)
     ResultStatus m_Status;
 };
 

--- a/Source/Api/Output/KernelResult.h
+++ b/Source/Api/Output/KernelResult.h
@@ -134,17 +134,29 @@ public:
       */
     Nanoseconds GetKernelDuration() const;
 
-    /** @fn Nanoseconds GetKernelOverhead() const
+    /** @fn Nanoseconds GetKernelOverheadFromCompResults() const
       * Retrieves total kernel overhead from the partial results.
       * @return Total kernel overhead from the partial results.
       */
+    Nanoseconds GetKernelOverheadFromCompResults() const;
+
+    /** @fn Nanoseconds GetKernelOverhead() const
+      * Retrieves total kernel overhead.
+      * @return Total kernel overhead.
+      */
     Nanoseconds GetKernelOverhead() const;
+
+    /** @fn Nanoseconds GetKernelOverheadFirstPass() const
+      * Retrieves kernel overhead of the first pass under the same configuration.
+      * @return Kernel overhead of the first pass under the same configuration.
+      */
+    Nanoseconds GetKernelOverheadFirstPass() const;
 
     /** @fn Nanoseconds GetKernelCompilationOverhead() const
       * Retrieves total kernel compilation overhead from the partial results.
       * @return Total kernel compilation overhead from the partial results.
       */
-    Nanoseconds GetKernelCompilationOverhead() const;
+    Nanoseconds GetCompilationOverheadFromCompResults() const;
 
     /** @fn Nanoseconds GetExtraDuration() const
       * Retrieves duration of a kernel launcher. The duration of buffer transfers performed within the launcher is not included.
@@ -189,9 +201,22 @@ public:
       */
     Nanoseconds GetProfilingRunsOverhead() const;
 
+    
+    /** @fn Nanoseconds GetProfilingInfrastructureOverhead() const
+      * Retrieves duration of CUPTI initialization and data collection, but without data movement and extra duration, for all profiling passes.
+      * @return Duration of profiling infrastructure, but without data movement and extra duration.
+      */
+    Nanoseconds GetProfilingInfrastructureOverhead() const;
+
+    /** @fn Nanoseconds GetProfilingOverheadFromCompResults() const
+      * Retrieves duration of all non-kernel operations performed during collection performance counters (e.g., data movements for extra kernel runs) from the partial results.
+      * @return Duration of operations different than kernel execution needed to collect performance counters from the partial results.
+      */
+    Nanoseconds GetProfilingOverheadFromCompResults() const;
+
     /** @fn Nanoseconds GetProfilingOverhead() const
-      * Retrieves duration of all non-kernel operations performed during collection performance counters (e.g., data movements for extra kernel runs).
-      * @return Duration operations different than kernel execution needed to coollect performance counters.
+      * Retrieves duration of all non-kernel operations performed during collection performance counters (e.g., CUPTI infrastructure and data movements for extra kernel runs) for all profiling runs.
+      * @return Duration operations different than kernel execution needed to collect performance counters.
       */
     Nanoseconds GetProfilingOverhead() const;
 
@@ -219,6 +244,12 @@ public:
       * @return The sum of kernel, data movement, validation and searcher overhead.
       */
     Nanoseconds GetTotalOverhead() const;
+
+    /** @fn Nanoseconds ComputeTotalOverhead() const
+      * Computes the total overhead by summing up all individual overhead components.
+      * @return Total overhead.
+      */
+    Nanoseconds ComputeTotalOverhead() const;
 
     /** @fn bool IsValid() const
       * Checks whether kernel result is valid. I.e., its status has value Ok.
@@ -264,7 +295,11 @@ private:
     Nanoseconds m_FailedKernelOverhead;
     Nanoseconds m_ProfilingRunsOverhead;
     Nanoseconds m_ProfilingOverhead;
+    Nanoseconds m_ProfilingInfrastructureOverhead;
     Nanoseconds m_CompilationOverhead;
+    Nanoseconds m_KernelOverhead;
+    Nanoseconds m_KernelOverheadFirstPass;
+    Nanoseconds m_TotalOverhead;
     ResultStatus m_Status;
 };
 

--- a/Source/Api/Output/KernelResult.h
+++ b/Source/Api/Output/KernelResult.h
@@ -164,6 +164,12 @@ public:
       */
     Nanoseconds GetExtraDuration() const;
 
+    /** @fn Nanoseconds GetExtraDurationFirstPass() const
+      * Retrieves extra duration of a kernel launcher from the first (non-profiling) pass.
+      * @return Kernel launcher extra duration from the first pass.
+      */
+    Nanoseconds GetExtraDurationFirstPass() const;
+
     /** @fn Nanoseconds GetExtraOverhead() const
       * Retrieves duration of buffer transfers (e.g., between host and device memory).
       * @return Duration of buffer transfers.
@@ -287,12 +293,13 @@ private:
     Nanoseconds m_ValidationOverhead;
     Nanoseconds m_SearcherOverhead;
     Nanoseconds m_FailedKernelOverhead;
-    Nanoseconds m_ProfilingRunsOverhead; //overhead of all profiling runs, including kernel overhead and kernel duration of extra passes
-    Nanoseconds m_ProfilingOverhead; //overhead of profiling infrastructure, with data movement and extra duration, for all profiling passes
+    Nanoseconds m_ProfilingRunsOverhead; //overhead of all profiling runs, including kernel overhead and kernel duration and extra duration of extra passes
+    Nanoseconds m_ProfilingOverhead; //overhead of profiling infrastructure, with data movement and validation, for all profiling passes
     Nanoseconds m_ProfilingInfrastructureOverhead; //overhead of profiling infrastructure, but without data movement and extra duration, for all profiling passes
     Nanoseconds m_CompilationOverhead;
     Nanoseconds m_KernelOverhead;
     Nanoseconds m_KernelOverheadFirstPass; //kernel overhead of the first pass (i.e. full compilation and run without profiling)
+    Nanoseconds m_ExtraDurationFirstPass; //extra duration of the first pass 
     ResultStatus m_Status;
 };
 

--- a/Source/ComputeEngine/Cuda/Actions/CudaComputeAction.cpp
+++ b/Source/ComputeEngine/Cuda/Actions/CudaComputeAction.cpp
@@ -16,6 +16,7 @@ CudaComputeAction::CudaComputeAction(const ComputeActionId id, const QueueId que
     m_Kernel(kernel),
     m_Overhead(0),
     m_CompilationOverhead(0),
+    m_ProfilingOverhead(0),
     m_GlobalSize(globalSize),
     m_LocalSize(localSize)
 {
@@ -37,6 +38,10 @@ void CudaComputeAction::IncreaseCompilationOverhead(const Nanoseconds overhead)
     m_CompilationOverhead += overhead;
 }
 
+void CudaComputeAction::IncreaseProfilingOverhead(const Nanoseconds overhead)
+{
+    m_ProfilingOverhead += overhead;
+}
 
 void CudaComputeAction::SetComputeId(const KernelComputeId& id)
 {
@@ -124,6 +129,11 @@ Nanoseconds CudaComputeAction::GetCompilationOverhead() const
     return m_CompilationOverhead;
 }
 
+Nanoseconds CudaComputeAction::GetProfilingOverhead() const
+{
+    return m_ProfilingOverhead;
+}
+
 const KernelComputeId& CudaComputeAction::GetComputeId() const
 {
     return m_ComputeId;
@@ -139,9 +149,10 @@ ComputationResult CudaComputeAction::GenerateResult() const
         duration = GetDuration();
     const Nanoseconds overhead = GetOverhead();
     const Nanoseconds compilationOverhead = GetCompilationOverhead();
+    const Nanoseconds profilingOverhead = GetProfilingOverhead();
     std::unique_ptr<KernelCompilationData> compilationData = m_Kernel->GenerateCompilationData();
 
-    result.SetDurationData(duration, overhead, compilationOverhead);
+    result.SetDurationData(duration, overhead, compilationOverhead, profilingOverhead);
     result.SetSizeData(m_GlobalSize, m_LocalSize);
     result.SetCompilationData(std::move(compilationData));
     

--- a/Source/ComputeEngine/Cuda/Actions/CudaComputeAction.cpp
+++ b/Source/ComputeEngine/Cuda/Actions/CudaComputeAction.cpp
@@ -17,6 +17,7 @@ CudaComputeAction::CudaComputeAction(const ComputeActionId id, const QueueId que
     m_Overhead(0),
     m_CompilationOverhead(0),
     m_ProfilingOverhead(0),
+    m_PreciseMeasurementOverhead(0),
     m_GlobalSize(globalSize),
     m_LocalSize(localSize)
 {
@@ -41,6 +42,11 @@ void CudaComputeAction::IncreaseCompilationOverhead(const Nanoseconds overhead)
 void CudaComputeAction::IncreaseProfilingOverhead(const Nanoseconds overhead)
 {
     m_ProfilingOverhead += overhead;
+}
+
+void CudaComputeAction::IncreasePreciseMeasurementOverhead(const Nanoseconds overhead)
+{
+    m_PreciseMeasurementOverhead += overhead;
 }
 
 void CudaComputeAction::SetComputeId(const KernelComputeId& id)
@@ -134,6 +140,11 @@ Nanoseconds CudaComputeAction::GetProfilingOverhead() const
     return m_ProfilingOverhead;
 }
 
+Nanoseconds CudaComputeAction::GetPreciseMeasurementOverhead() const
+{
+    return m_PreciseMeasurementOverhead;
+}
+
 const KernelComputeId& CudaComputeAction::GetComputeId() const
 {
     return m_ComputeId;
@@ -150,9 +161,10 @@ ComputationResult CudaComputeAction::GenerateResult() const
     const Nanoseconds overhead = GetOverhead();
     const Nanoseconds compilationOverhead = GetCompilationOverhead();
     const Nanoseconds profilingOverhead = GetProfilingOverhead();
+    const Nanoseconds preciseMeasurementOverhead = GetPreciseMeasurementOverhead();
     std::unique_ptr<KernelCompilationData> compilationData = m_Kernel->GenerateCompilationData();
 
-    result.SetDurationData(duration, overhead, compilationOverhead, profilingOverhead);
+    result.SetDurationData(duration, overhead, compilationOverhead, profilingOverhead, preciseMeasurementOverhead);
     result.SetSizeData(m_GlobalSize, m_LocalSize);
     result.SetCompilationData(std::move(compilationData));
     

--- a/Source/ComputeEngine/Cuda/Actions/CudaComputeAction.h
+++ b/Source/ComputeEngine/Cuda/Actions/CudaComputeAction.h
@@ -24,6 +24,7 @@ public:
     void IncreaseOverhead(const Nanoseconds overhead);
     void IncreaseCompilationOverhead(const Nanoseconds overhead);
     void IncreaseProfilingOverhead(const Nanoseconds overhead);
+    void IncreasePreciseMeasurementOverhead(const Nanoseconds overhead);
     void SetComputeId(const KernelComputeId& id);
     void SetPowerUsage(const uint32_t powerUsage);
     void SetTemperature(const double temperature);
@@ -43,6 +44,7 @@ public:
     Nanoseconds GetOverhead() const;
     Nanoseconds GetCompilationOverhead() const;
     Nanoseconds GetProfilingOverhead() const;
+    Nanoseconds GetPreciseMeasurementOverhead() const;
     const KernelComputeId& GetComputeId() const;
     ComputationResult GenerateResult() const;
 
@@ -55,6 +57,7 @@ private:
     Nanoseconds m_Overhead;
     Nanoseconds m_CompilationOverhead;
     Nanoseconds m_ProfilingOverhead;
+    Nanoseconds m_PreciseMeasurementOverhead;
     KernelComputeId m_ComputeId;
     DimensionVector m_GlobalSize;
     DimensionVector m_LocalSize;

--- a/Source/ComputeEngine/Cuda/Actions/CudaComputeAction.h
+++ b/Source/ComputeEngine/Cuda/Actions/CudaComputeAction.h
@@ -23,6 +23,7 @@ public:
 
     void IncreaseOverhead(const Nanoseconds overhead);
     void IncreaseCompilationOverhead(const Nanoseconds overhead);
+    void IncreaseProfilingOverhead(const Nanoseconds overhead);
     void SetComputeId(const KernelComputeId& id);
     void SetPowerUsage(const uint32_t powerUsage);
     void SetTemperature(const double temperature);
@@ -41,6 +42,7 @@ public:
     Nanoseconds GetDuration() const;
     Nanoseconds GetOverhead() const;
     Nanoseconds GetCompilationOverhead() const;
+    Nanoseconds GetProfilingOverhead() const;
     const KernelComputeId& GetComputeId() const;
     ComputationResult GenerateResult() const;
 
@@ -52,6 +54,7 @@ private:
     std::unique_ptr<CudaEvent> m_EndEvent;
     Nanoseconds m_Overhead;
     Nanoseconds m_CompilationOverhead;
+    Nanoseconds m_ProfilingOverhead;
     KernelComputeId m_ComputeId;
     DimensionVector m_GlobalSize;
     DimensionVector m_LocalSize;

--- a/Source/ComputeEngine/Cuda/CudaEngine.cpp
+++ b/Source/ComputeEngine/Cuda/CudaEngine.cpp
@@ -1162,15 +1162,7 @@ void CudaEngine::FillProfilingData(const KernelComputeId& id, ComputationResult&
 
     if (profilingData->IsValid())
     {
-        KttAssert(instance.HasValidKernelDuration(), "Kernel duration must be known before filling in profiling data");
-        uint64_t profiledKernelOverhead = 0;
-
-        if (result.GetDuration() > instance.GetKernelDuration())
-        {
-            profiledKernelOverhead = result.GetDuration() - instance.GetKernelDuration();
-        }
-
-        result.SetDurationData(result.GetDuration() - profiledKernelOverhead, result.GetOverhead(), result.GetCompilationOverhead(), result.GetProfilingOverhead() + profiledKernelOverhead);
+        result.SetDurationData(result.GetDuration(), result.GetOverhead(), result.GetCompilationOverhead(), result.GetProfilingOverhead());
         m_CuptiInstances.erase(id);
     }
 
@@ -1196,14 +1188,7 @@ void CudaEngine::FillProfilingData(const KernelComputeId& id, ComputationResult&
 
     if (profilingData->IsValid())
     {
-        uint64_t profiledKernelOverhead = 0;
-
-        if (result.GetDuration() > instance.GetKernelDuration())
-        {
-            profiledKernelOverhead = result.GetDuration() - instance.GetKernelDuration();
-        }
-
-        result.SetDurationData(result.GetDuration() - profiledKernelOverhead, result.GetOverhead(), result.GetCompilationOverhead(), result.GetProfilingOverhead() + profiledKernelOverhead);
+        result.SetDurationData(result.GetDuration(), result.GetOverhead(), result.GetCompilationOverhead(), result.GetProfilingOverhead());
         m_CuptiInstances.erase(id);
     }
 

--- a/Source/ComputeEngine/Cuda/CudaEngine.cpp
+++ b/Source/ComputeEngine/Cuda/CudaEngine.cpp
@@ -283,6 +283,11 @@ ComputeActionId CudaEngine::RunKernelAsync(const KernelComputeData& data, const 
             }
         }
         pwrTimer.Stop();
+        // pwrTimer starts before the first kernel launch (line ~225), so the recorded
+        // overhead includes the initial execution and first NVML sample collection in
+        // addition to the stabilization while-loop. This is intentional: the entire
+        // precise-measurement block is treated as overhead.
+        action->IncreasePreciseMeasurementOverhead(pwrTimer.GetElapsedTime());
 
         // Calculate duration and standard deviation using utility methods
         const auto measurementResult = PreciseMeasurementParameters::ComputeDurationAndStdev(
@@ -327,7 +332,8 @@ ComputeActionId CudaEngine::RunKernelAsync(const KernelComputeData& data, const 
     
     if (preciseParams.has_value())
     {
-        // Execute kernel multiple times for stable timing measurement using utility
+        Timer preciseMeasurementTimer;
+        preciseMeasurementTimer.Start();
         const auto& params = preciseParams.value();
         const auto result = MeasurementUtility::ExecuteWithStableTiming(
             [&]() -> Nanoseconds {
@@ -337,9 +343,11 @@ ComputeActionId CudaEngine::RunKernelAsync(const KernelComputeData& data, const 
             },
             params,
             "CUDA");
-        
+
         action->SetDurationFromMultirun(result.duration);
         action->SetDurationStdev(result.standardDeviation);
+        preciseMeasurementTimer.Stop();
+        action->IncreasePreciseMeasurementOverhead(preciseMeasurementTimer.GetElapsedTime());
     }
 #endif // KTT_POWER_USAGE_NVML
 

--- a/Source/ComputeEngine/Cuda/CudaEngine.cpp
+++ b/Source/ComputeEngine/Cuda/CudaEngine.cpp
@@ -425,7 +425,7 @@ ComputationResult CudaEngine::RunKernelWithProfiling([[maybe_unused]] const Kern
     // On subsequent runs, pass nullopt to avoid re-running measurement
     const auto actionId = RunKernelAsync(data, queueId, newProfiling, newProfiling ? preciseParams : std::nullopt);
     auto& action = *m_ComputeActions[actionId];
-    action.IncreaseOverhead(timer.GetElapsedTime());
+    action.IncreaseProfilingOverhead(timer.GetElapsedTime());
     ComputationResult result = WaitForComputeAction(actionId);
 
     if (!instance.HasValidKernelDuration())
@@ -438,7 +438,7 @@ ComputationResult CudaEngine::RunKernelWithProfiling([[maybe_unused]] const Kern
     FillProfilingData(id, result);
     timer.Stop();
 
-    result.SetDurationData(result.GetDuration(), result.GetOverhead() + timer.GetElapsedTime(), result.GetCompilationOverhead());
+    result.SetDurationData(result.GetDuration(), result.GetOverhead(), result.GetCompilationOverhead(), result.GetProfilingOverhead() + timer.GetElapsedTime());
     return result;
 
 #elif KTT_PROFILING_CUPTI
@@ -469,7 +469,7 @@ ComputationResult CudaEngine::RunKernelWithProfiling([[maybe_unused]] const Kern
     // On subsequent runs, pass nullopt to avoid re-running measurement
     const auto actionId = RunKernelAsync(data, queueId, newProfiling, newProfiling ? preciseParams : std::nullopt);
     auto& action = *m_ComputeActions[actionId];
-    action.IncreaseOverhead(timer.GetElapsedTime());
+    action.IncreaseProfilingOverhead(timer.GetElapsedTime()); 
     ComputationResult result = WaitForComputeAction(actionId);
     
     if (!instance.HasValidKernelDuration())
@@ -482,7 +482,7 @@ ComputationResult CudaEngine::RunKernelWithProfiling([[maybe_unused]] const Kern
     FillProfilingData(id, result);
     timer.Stop();
 
-    result.SetDurationData(result.GetDuration(), result.GetOverhead() + timer.GetElapsedTime(), result.GetCompilationOverhead());
+    result.SetDurationData(result.GetDuration(), result.GetOverhead(), result.GetCompilationOverhead(), result.GetProfilingOverhead() + timer.GetElapsedTime());
     return result;
 
 #else
@@ -1170,7 +1170,7 @@ void CudaEngine::FillProfilingData(const KernelComputeId& id, ComputationResult&
             profiledKernelOverhead = result.GetDuration() - instance.GetKernelDuration();
         }
 
-        result.SetDurationData(result.GetDuration() - profiledKernelOverhead, result.GetOverhead() + profiledKernelOverhead, result.GetCompilationOverhead());
+        result.SetDurationData(result.GetDuration() - profiledKernelOverhead, result.GetOverhead(), result.GetCompilationOverhead(), result.GetProfilingOverhead() + profiledKernelOverhead);
         m_CuptiInstances.erase(id);
     }
 
@@ -1203,7 +1203,7 @@ void CudaEngine::FillProfilingData(const KernelComputeId& id, ComputationResult&
             profiledKernelOverhead = result.GetDuration() - instance.GetKernelDuration();
         }
 
-        result.SetDurationData(result.GetDuration() - profiledKernelOverhead, result.GetOverhead() + profiledKernelOverhead, result.GetCompilationOverhead());
+        result.SetDurationData(result.GetDuration() - profiledKernelOverhead, result.GetOverhead(), result.GetCompilationOverhead(), result.GetProfilingOverhead() + profiledKernelOverhead);
         m_CuptiInstances.erase(id);
     }
 

--- a/Source/ComputeEngine/OpenCl/Actions/OpenClComputeAction.cpp
+++ b/Source/ComputeEngine/OpenCl/Actions/OpenClComputeAction.cpp
@@ -17,6 +17,7 @@ OpenClComputeAction::OpenClComputeAction(const ComputeActionId id, const QueueId
     m_Overhead(0),
     m_CompilationOverhead(0),
     m_ProfilingOverhead(0),
+    m_PreciseMeasurementOverhead(0),
     m_GlobalSize(globalSize),
     m_LocalSize(localSize),
     m_DurationFromMultirun(std::nullopt),
@@ -42,6 +43,11 @@ void OpenClComputeAction::IncreaseCompilationOverhead(const Nanoseconds overhead
 void OpenClComputeAction::IncreaseProfilingOverhead(const Nanoseconds overhead)
 {
     m_ProfilingOverhead += overhead;
+}
+
+void OpenClComputeAction::IncreasePreciseMeasurementOverhead(const Nanoseconds overhead)
+{
+    m_PreciseMeasurementOverhead += overhead;
 }
 
 void OpenClComputeAction::SetComputeId(const KernelComputeId& id)
@@ -106,8 +112,13 @@ Nanoseconds OpenClComputeAction::GetCompilationOverhead() const
 }
 
 Nanoseconds OpenClComputeAction::GetProfilingOverhead() const
-{    
+{
     return m_ProfilingOverhead;
+}
+
+Nanoseconds OpenClComputeAction::GetPreciseMeasurementOverhead() const
+{
+    return m_PreciseMeasurementOverhead;
 }
 
 const KernelComputeId& OpenClComputeAction::GetComputeId() const
@@ -122,6 +133,7 @@ ComputationResult OpenClComputeAction::GenerateResult() const
     const Nanoseconds overhead = GetOverhead();
     const Nanoseconds compilationOverhead = GetCompilationOverhead();
     const Nanoseconds profilingOverhead = GetProfilingOverhead();
+    const Nanoseconds preciseMeasurementOverhead = GetPreciseMeasurementOverhead();
     std::unique_ptr<KernelCompilationData> compilationData = m_Kernel->GenerateCompilationData();
 
     // Use duration from multirun if available
@@ -129,7 +141,7 @@ ComputationResult OpenClComputeAction::GenerateResult() const
         duration = m_DurationFromMultirun.value();
     }
 
-    result.SetDurationData(duration, overhead, compilationOverhead, profilingOverhead);
+    result.SetDurationData(duration, overhead, compilationOverhead, profilingOverhead, preciseMeasurementOverhead);
     result.SetSizeData(m_GlobalSize, m_LocalSize);
     result.SetCompilationData(std::move(compilationData));
 

--- a/Source/ComputeEngine/OpenCl/Actions/OpenClComputeAction.cpp
+++ b/Source/ComputeEngine/OpenCl/Actions/OpenClComputeAction.cpp
@@ -16,6 +16,7 @@ OpenClComputeAction::OpenClComputeAction(const ComputeActionId id, const QueueId
     m_Kernel(kernel),
     m_Overhead(0),
     m_CompilationOverhead(0),
+    m_ProfilingOverhead(0),
     m_GlobalSize(globalSize),
     m_LocalSize(localSize),
     m_DurationFromMultirun(std::nullopt),
@@ -36,6 +37,11 @@ void OpenClComputeAction::IncreaseOverhead(const Nanoseconds overhead)
 void OpenClComputeAction::IncreaseCompilationOverhead(const Nanoseconds overhead)
 {
     m_CompilationOverhead += overhead;
+}
+
+void OpenClComputeAction::IncreaseProfilingOverhead(const Nanoseconds overhead)
+{
+    m_ProfilingOverhead += overhead;
 }
 
 void OpenClComputeAction::SetComputeId(const KernelComputeId& id)
@@ -99,6 +105,11 @@ Nanoseconds OpenClComputeAction::GetCompilationOverhead() const
     return m_CompilationOverhead;
 }
 
+Nanoseconds OpenClComputeAction::GetProfilingOverhead() const
+{    
+    return m_ProfilingOverhead;
+}
+
 const KernelComputeId& OpenClComputeAction::GetComputeId() const
 {
     return m_ComputeId;
@@ -110,6 +121,7 @@ ComputationResult OpenClComputeAction::GenerateResult() const
     Nanoseconds duration = GetDuration();
     const Nanoseconds overhead = GetOverhead();
     const Nanoseconds compilationOverhead = GetCompilationOverhead();
+    const Nanoseconds profilingOverhead = GetProfilingOverhead();
     std::unique_ptr<KernelCompilationData> compilationData = m_Kernel->GenerateCompilationData();
 
     // Use duration from multirun if available
@@ -117,7 +129,7 @@ ComputationResult OpenClComputeAction::GenerateResult() const
         duration = m_DurationFromMultirun.value();
     }
 
-    result.SetDurationData(duration, overhead, compilationOverhead);
+    result.SetDurationData(duration, overhead, compilationOverhead, profilingOverhead);
     result.SetSizeData(m_GlobalSize, m_LocalSize);
     result.SetCompilationData(std::move(compilationData));
 

--- a/Source/ComputeEngine/OpenCl/Actions/OpenClComputeAction.h
+++ b/Source/ComputeEngine/OpenCl/Actions/OpenClComputeAction.h
@@ -23,6 +23,7 @@ public:
     void IncreaseOverhead(const Nanoseconds overhead);
     void IncreaseCompilationOverhead(const Nanoseconds overhead);
     void IncreaseProfilingOverhead(const Nanoseconds overhead);
+    void IncreasePreciseMeasurementOverhead(const Nanoseconds overhead);
     void SetComputeId(const KernelComputeId& id);
     void SetReleaseFlag();
     void SetDurationFromMultirun(const Nanoseconds duration);
@@ -37,6 +38,7 @@ public:
     Nanoseconds GetOverhead() const;
     Nanoseconds GetCompilationOverhead() const;
     Nanoseconds GetProfilingOverhead() const;
+    Nanoseconds GetPreciseMeasurementOverhead() const;
     const KernelComputeId& GetComputeId() const;
     ComputationResult GenerateResult() const;
 
@@ -48,6 +50,7 @@ private:
     Nanoseconds m_Overhead;
     Nanoseconds m_CompilationOverhead;
     Nanoseconds m_ProfilingOverhead;
+    Nanoseconds m_PreciseMeasurementOverhead;
     KernelComputeId m_ComputeId;
     DimensionVector m_GlobalSize;
     DimensionVector m_LocalSize;

--- a/Source/ComputeEngine/OpenCl/Actions/OpenClComputeAction.h
+++ b/Source/ComputeEngine/OpenCl/Actions/OpenClComputeAction.h
@@ -22,6 +22,7 @@ public:
 
     void IncreaseOverhead(const Nanoseconds overhead);
     void IncreaseCompilationOverhead(const Nanoseconds overhead);
+    void IncreaseProfilingOverhead(const Nanoseconds overhead);
     void SetComputeId(const KernelComputeId& id);
     void SetReleaseFlag();
     void SetDurationFromMultirun(const Nanoseconds duration);
@@ -35,6 +36,7 @@ public:
     Nanoseconds GetDuration() const;
     Nanoseconds GetOverhead() const;
     Nanoseconds GetCompilationOverhead() const;
+    Nanoseconds GetProfilingOverhead() const;
     const KernelComputeId& GetComputeId() const;
     ComputationResult GenerateResult() const;
 
@@ -45,6 +47,7 @@ private:
     std::unique_ptr<OpenClEvent> m_Event;
     Nanoseconds m_Overhead;
     Nanoseconds m_CompilationOverhead;
+    Nanoseconds m_ProfilingOverhead;
     KernelComputeId m_ComputeId;
     DimensionVector m_GlobalSize;
     DimensionVector m_LocalSize;

--- a/Source/ComputeEngine/OpenCl/OpenClEngine.cpp
+++ b/Source/ComputeEngine/OpenCl/OpenClEngine.cpp
@@ -322,7 +322,7 @@ ComputationResult OpenClEngine::RunKernelWithProfiling([[maybe_unused]] const Ke
     (void)powerParams;
     const auto actionId = RunKernelAsync(data, queueId);
     auto& action = *m_ComputeActions[actionId];
-    action.IncreaseOverhead(timer.GetElapsedTime());
+    action.IncreaseProfilingOverhead(timer.GetElapsedTime());
 
     ComputationResult result = WaitForComputeAction(actionId);
 
@@ -331,7 +331,7 @@ ComputationResult OpenClEngine::RunKernelWithProfiling([[maybe_unused]] const Ke
     FillProfilingData(id, result);
     timer.Stop();
 
-    result.SetDurationData(result.GetDuration(), result.GetOverhead() + timer.GetElapsedTime(), result.GetCompilationOverhead());
+    result.SetDurationData(result.GetDuration(), result.GetOverhead(), result.GetCompilationOverhead(), result.GetProfilingOverhead() + timer.GetElapsedTime());
     return result;
 #else
     throw KttException("Support for kernel profiling is not included in this version of KTT framework");

--- a/Source/ComputeEngine/OpenCl/OpenClEngine.cpp
+++ b/Source/ComputeEngine/OpenCl/OpenClEngine.cpp
@@ -232,6 +232,8 @@ ComputeActionId OpenClEngine::RunKernelAsync(const KernelComputeData& data, cons
     // OpenCL does not support power measurement, but preciseParams can be used for stable timing
     if (preciseParams.has_value())
     {
+        Timer preciseMeasurementTimer;
+        preciseMeasurementTimer.Start();
         const auto& params = preciseParams.value();
         const auto result = MeasurementUtility::ExecuteWithStableTiming(
             [&]() -> Nanoseconds {
@@ -241,9 +243,11 @@ ComputeActionId OpenClEngine::RunKernelAsync(const KernelComputeData& data, cons
             },
             params,
             "OpenCL");
-        
+
         action->SetDurationFromMultirun(result.duration);
         action->SetDurationStdev(result.standardDeviation);
+        preciseMeasurementTimer.Stop();
+        action->IncreasePreciseMeasurementOverhead(preciseMeasurementTimer.GetElapsedTime());
     }
 
     action->IncreaseOverhead(timer.GetElapsedTime());

--- a/Source/KernelRunner/ComputeLayerData.cpp
+++ b/Source/KernelRunner/ComputeLayerData.cpp
@@ -149,9 +149,13 @@ Nanoseconds ComputeLayerData::CalculateLauncherOverhead() const
 
     for (const auto& partialResult : m_PartialResults)
     {
-        result += partialResult.GetDuration();
+        // if precise measurement is used, the duration of the run is included in the precise measurement overhead
+        // so, to avoid double counting, we only add the raw duration if precise measurement overhead is not present
+        if (partialResult.GetPreciseMeasurementOverhead() == 0)
+            result += partialResult.GetDuration();
         result += partialResult.GetOverhead();
         result += partialResult.GetProfilingOverhead();
+        result += partialResult.GetPreciseMeasurementOverhead();
     }
 
     return result;

--- a/Source/KernelRunner/ComputeLayerData.cpp
+++ b/Source/KernelRunner/ComputeLayerData.cpp
@@ -151,6 +151,7 @@ Nanoseconds ComputeLayerData::CalculateLauncherOverhead() const
     {
         result += partialResult.GetDuration();
         result += partialResult.GetOverhead();
+        result += partialResult.GetProfilingOverhead();
     }
 
     return result;

--- a/Source/KernelRunner/ComputeLayerData.h
+++ b/Source/KernelRunner/ComputeLayerData.h
@@ -24,7 +24,6 @@ public:
         const KernelRunMode runMode);
 
     void IncreaseOverhead(const Nanoseconds overhead);
-    void IncreaseCompilationOverhead(const Nanoseconds overhead);
     void AddPartialResult(const ComputationResult& result);
     void AddArgumentOverride(const ArgumentId& id, const KernelArgument& argument);
     void SwapArguments(const KernelDefinitionId id, const ArgumentId& first, const ArgumentId& second);

--- a/Source/Output/JsonConverters.cpp
+++ b/Source/Output/JsonConverters.cpp
@@ -417,6 +417,7 @@ void to_json(json& j, const KernelResult& result)
         {"SearcherOverhead", time.ConvertFromNanosecondsDouble(result.GetSearcherOverhead())},
         {"CompilationOverhead", time.ConvertFromNanosecondsDouble(result.GetCompilationOverhead())},
         {"ProfilingOverhead", time.ConvertFromNanosecondsDouble(result.GetProfilingTotalOverhead())},
+        {"PreciseMeasurementOverhead", time.ConvertFromNanosecondsDouble(result.GetPreciseMeasurementOverhead())},
         {"Configuration", result.GetConfiguration()},
         {"ComputationResults", result.GetResults()},
         {"Timestamp", result.GetTimestamp()}
@@ -464,6 +465,12 @@ void from_json(const json& j, KernelResult& result)
     j.at("SearcherOverhead").get_to(searcherOverhead);
     const Nanoseconds searcherOverheadNs = time.ConvertToNanosecondsDouble(searcherOverhead);
     result.SetSearcherOverhead(searcherOverheadNs);
+
+    double preciseMeasurementOverhead = 0.0;
+    if (j.contains("PreciseMeasurementOverhead"))
+        j.at("PreciseMeasurementOverhead").get_to(preciseMeasurementOverhead);
+    const Nanoseconds preciseMeasurementOverheadNs = time.ConvertToNanosecondsDouble(preciseMeasurementOverhead);
+    result.SetPreciseMeasurementOverhead(preciseMeasurementOverheadNs);
 }
 
 } // namespace ktt

--- a/Source/Output/JsonT4Converters.cpp
+++ b/Source/Output/JsonT4Converters.cpp
@@ -97,7 +97,7 @@ void to_json(json& j, const as_T4<const KernelResult>& result)
     j["times"]["profiling_runs"] = time.ConvertFromNanosecondsDouble(result.v.GetProfilingRunsOverhead());
     j["times"]["profiling_overhead"] = time.ConvertFromNanosecondsDouble(result.v.GetProfilingOverhead());
     j["times"]["kernel_overhead"] = time.ConvertFromNanosecondsDouble(result.v.GetKernelOverhead());
-    j["times"]["framework"] = time.ConvertFromNanosecondsDouble(result.v.GetDataMovementOverhead()) + time.ConvertFromNanosecondsDouble(result.v.GetProfilingTotalOverhead()) + time.ConvertFromNanosecondsDouble(result.v.GetKernelOverhead());
+    j["times"]["framework"] = time.ConvertFromNanosecondsDouble(result.v.GetTotalOverhead());
     j["times"]["search_algorithm"] = time.ConvertFromNanosecondsDouble(result.v.GetSearcherOverhead());
     j["times"]["validation"] = time.ConvertFromNanosecondsDouble(result.v.GetValidationOverhead());
     j["times"]["runtimes"] = json::array({time.ConvertFromNanosecondsDouble(result.v.GetTotalDuration())});
@@ -195,7 +195,7 @@ void from_json(const json& j, as_T4<KernelResult>& result)
 
     // search_overhead is measured again in simulated tuning, so we are not deserializing it
 
-    computationResult.SetDurationData(durationNs, kernelOverheadNs, compilationOverheadNs);
+    computationResult.SetDurationData(durationNs, kernelOverheadNs, compilationOverheadNs, profilingOverheadNs);
     if (j.at("measurements").size() > 1) {
         json j_measurements = j.at("measurements");
         //remove "time" measurement
@@ -262,7 +262,6 @@ void from_json(const json& j, as_T4<KernelResult>& result)
     result.v = KernelResult(kernelName, configuration, results, timestamp);
     result.v.SetDataMovementOverhead(dataMovementOverheadNs);
     result.v.SetProfilingRunsOverhead(profilingRunsOverheadNs);
-    result.v.SetProfilingOverhead(profilingOverheadNs);
     result.v.SetValidationOverhead(validationOverheadNs);
 
     ResultStatus status;

--- a/Source/Output/JsonT4Converters.cpp
+++ b/Source/Output/JsonT4Converters.cpp
@@ -100,6 +100,7 @@ void to_json(json& j, const as_T4<const KernelResult>& result)
     j["times"]["framework"] = time.ConvertFromNanosecondsDouble(result.v.GetTotalOverhead());
     j["times"]["search_algorithm"] = time.ConvertFromNanosecondsDouble(result.v.GetSearcherOverhead());
     j["times"]["validation"] = time.ConvertFromNanosecondsDouble(result.v.GetValidationOverhead());
+    j["times"]["precise_measurement"] = time.ConvertFromNanosecondsDouble(result.v.GetPreciseMeasurementOverhead());
     j["times"]["runtimes"] = json::array({time.ConvertFromNanosecondsDouble(result.v.GetTotalDuration())});
     const ResultStatus& resultStatus = result.v.GetStatus();
     to_json(j["invalidity"], as_T4(resultStatus));
@@ -193,6 +194,11 @@ void from_json(const json& j, as_T4<KernelResult>& result)
     j.at("times").at("validation").get_to(validationOverhead);
     const Nanoseconds validationOverheadNs = time.ConvertToNanosecondsDouble(validationOverhead);
 
+    double preciseMeasurementOverhead = 0.0;
+    if (j.at("times").contains("precise_measurement"))
+        j.at("times").at("precise_measurement").get_to(preciseMeasurementOverhead);
+    const Nanoseconds preciseMeasurementOverheadNs = time.ConvertToNanosecondsDouble(preciseMeasurementOverhead);
+
     // search_overhead is measured again in simulated tuning, so we are not deserializing it
 
     computationResult.SetDurationData(durationNs, kernelOverheadNs, compilationOverheadNs, profilingOverheadNs);
@@ -263,6 +269,7 @@ void from_json(const json& j, as_T4<KernelResult>& result)
     result.v.SetDataMovementOverhead(dataMovementOverheadNs);
     result.v.SetProfilingRunsOverhead(profilingRunsOverheadNs);
     result.v.SetValidationOverhead(validationOverheadNs);
+    result.v.SetPreciseMeasurementOverhead(preciseMeasurementOverheadNs);
 
     ResultStatus status;
     auto statusWrapper = as_T4(status);

--- a/Source/Output/XmlConverters.cpp
+++ b/Source/Output/XmlConverters.cpp
@@ -716,6 +716,9 @@ void AppendKernelResult(pugi::xml_node parent, const KernelResult& result)
         xmlFloatingPointPrecision);
     node.append_attribute("ProfilingOverhead").set_value(time.ConvertFromNanosecondsDouble(result.GetProfilingTotalOverhead()),
         xmlFloatingPointPrecision);
+    node.append_attribute("PreciseMeasurementOverhead").set_value(
+        time.ConvertFromNanosecondsDouble(result.GetPreciseMeasurementOverhead()),
+        xmlFloatingPointPrecision);
     AppendConfiguration(node, result.GetConfiguration());
 
     pugi::xml_node computationResults = node.append_child("ComputationResults");
@@ -761,6 +764,10 @@ KernelResult ParseKernelResult(const pugi::xml_node node)
     const double searcherOverhead = node.attribute("SearcherOverhead").as_double();
     const Nanoseconds searcherOverheadNs = time.ConvertToNanosecondsDouble(searcherOverhead);
     result.SetSearcherOverhead(searcherOverheadNs);
+
+    const double preciseMeasurementOverhead = node.attribute("PreciseMeasurementOverhead").as_double();
+    const Nanoseconds preciseMeasurementOverheadNs = time.ConvertToNanosecondsDouble(preciseMeasurementOverhead);
+    result.SetPreciseMeasurementOverhead(preciseMeasurementOverheadNs);
 
     return result;
 }

--- a/Source/Python/PythonTuner.cpp
+++ b/Source/Python/PythonTuner.cpp
@@ -184,7 +184,7 @@ void InitializePythonTuner(py::module_& module)
             py::arg("id"),
             py::arg("name"),
             py::arg("valueType"),
-            py::arg("valueScript"),
+            py::arg("valueScript")
         )
         .def("AddThreadModifier", py::overload_cast<const ktt::KernelId, const std::vector<ktt::KernelDefinitionId>&, const ktt::ModifierType,
             const ktt::ModifierDimension, const std::vector<std::string>&, ktt::ModifierFunction>(&ktt::Tuner::AddThreadModifier))
@@ -533,22 +533,25 @@ void InitializePythonTuner(py::module_& module)
         .def
         (
             "TuneOptions",
-            py::overload_cast<const ktt::KernelId, const ktt::KernelConfiguration&, std::unique_ptr<ktt::StopCondition>>(&ktt::Tuner::TuneOptions),
+            py::overload_cast<const ktt::KernelId, const ktt::KernelConfiguration&, std::unique_ptr<ktt::StopCondition>,
+                const std::optional<ktt::PreciseMeasurementParameters>&>(&ktt::Tuner::TuneOptions),
             py::call_guard<py::gil_scoped_release>(),
             py::arg("id"),
             py::arg("baseConfiguration"),
-            py::arg("stopCondition") = nullptr
+            py::arg("stopCondition") = nullptr,
+            py::arg("preciseParams") = std::nullopt
         )
         .def
         (
             "TuneOptions",
             py::overload_cast<const ktt::KernelId, const ktt::KernelConfiguration&, const ktt::KernelDimensions&,
-                std::unique_ptr<ktt::StopCondition>>(&ktt::Tuner::TuneOptions),
+                std::unique_ptr<ktt::StopCondition>, const std::optional<ktt::PreciseMeasurementParameters>&>(&ktt::Tuner::TuneOptions),
             py::call_guard<py::gil_scoped_release>(),
             py::arg("id"),
             py::arg("baseConfiguration"),
             py::arg("dimensions"),
-            py::arg("stopCondition") = nullptr
+            py::arg("stopCondition") = nullptr,
+            py::arg("preciseParams") = std::nullopt
         )
         .def
         (

--- a/Source/TuningRunner/TuningRunner.cpp
+++ b/Source/TuningRunner/TuningRunner.cpp
@@ -61,9 +61,10 @@ std::vector<KernelResult> TuningRunner::Tune(const Kernel& kernel, const KernelD
             iter++;
         }
         while (result.HasRemainingProfilingRuns());
+        //has to be called even if there are no profiling runs, as it copies data from the (first) pass from multiResult to result, which is needed for correct total overhead and total duration calculation  and for correct reporting in the output
+        result.CopyProfilingTimes(multiResult);
         if (iter > 1) //do not copy the same result twice
         {
-            result.CopyProfilingTimes(multiResult);
             result.TransferPowerData(multiResult);
         }
 

--- a/Source/TuningRunner/TuningRunner.cpp
+++ b/Source/TuningRunner/TuningRunner.cpp
@@ -73,6 +73,8 @@ std::vector<KernelResult> TuningRunner::Tune(const Kernel& kernel, const KernelD
         });
 
         result.SetSearcherOverhead(searcherOverhead);
+        //no need to explicitly recompute total overhead here, as it is computed on demand in GetTotalOverhead() method,
+        // now with an updated searcher overhead value
         results.push_back(result);
 
         if (stopCondition == nullptr)

--- a/Tutorials/03KernelTuning/FullSearchSpace.ktt.json
+++ b/Tutorials/03KernelTuning/FullSearchSpace.ktt.json
@@ -6,11 +6,11 @@
     "KttVersion": "2.2.0",
     "Platform": "NVIDIA CUDA",
     "TimeUnit": "Microseconds",
-    "Timestamp": "2025-10-21 09:06:3 UTC"
+    "Timestamp": "2026-04-21 07:19:6 UTC"
   },
   "Results": [
     {
-      "CompilationOverhead": 83852.794,
+      "CompilationOverhead": 9265.11,
       "ComputationResults": [
         {
           "CompilationData": {
@@ -20,8 +20,8 @@
             "PrivateMemorySize": 0,
             "RegistersCount": 12
           },
-          "CompilationOverhead": 1.707,
-          "Duration": 88.8,
+          "CompilationOverhead": 9253.058,
+          "Duration": 89.536,
           "GlobalSize": {
             "X": 32768,
             "Y": 1,
@@ -33,43 +33,43 @@
             "Y": 1,
             "Z": 1
           },
-          "Overhead": 8863.682,
+          "Overhead": 9253.058,
           "ProfilingData": {
             "Counters": [
               {
                 "Name": "dram__throughput.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 19.266317437379577
+                "Value": 1.1848341232227488
               },
               {
                 "Name": "dram__sectors_read.sum",
                 "Type": "Double",
-                "Value": 1920.0
+                "Value": 408.0
               },
               {
                 "Name": "dram__sectors_write.sum",
                 "Type": "Double",
-                "Value": 49276.0
+                "Value": 2792.0
               },
               {
                 "Name": "lts__t_sectors.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 19.896207746052262
+                "Value": 19.631978939002583
               },
               {
                 "Name": "lts__t_sectors_op_read.sum",
                 "Type": "Double",
-                "Value": 262887.0
+                "Value": 263574.0
               },
               {
                 "Name": "lts__t_sectors_op_write.sum",
                 "Type": "Double",
-                "Value": 131097.0
+                "Value": 131521.0
               },
               {
                 "Name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 6.341532801582287
+                "Value": 6.310907732248645
               },
               {
                 "Name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.sum",
@@ -79,7 +79,7 @@
               {
                 "Name": "l1tex__data_pipe_lsu_wavefronts_mem_shared.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 1.4820711365198829
+                "Value": 1.4581961231064988
               },
               {
                 "Name": "l1tex__data_pipe_lsu_wavefronts_mem_shared_op_ld.sum",
@@ -104,12 +104,12 @@
               {
                 "Name": "sm__warps_active.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 25.041872653268708
+                "Value": 24.798153861758866
               },
               {
                 "Name": "smsp__cycles_active.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 41.402750388971306
+                "Value": 40.002347407394225
               },
               {
                 "Name": "smsp__sass_thread_inst_executed_op_fp16_pred_on.sum",
@@ -159,7 +159,7 @@
               {
                 "Name": "smsp__pipe_fma_cycles_active.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 8.054472465945834
+                "Value": 8.202316844134899
               },
               {
                 "Name": "smsp__inst_executed_pipe_fp64.avg.pct_of_peak_sustained_active",
@@ -174,7 +174,7 @@
               {
                 "Name": "smsp__inst_executed_pipe_lsu.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 7.1592883206844675
+                "Value": 7.2905527680955995
               },
               {
                 "Name": "smsp__inst_executed_pipe_tex.avg.pct_of_peak_sustained_active",
@@ -184,7 +184,7 @@
               {
                 "Name": "smsp__issue_active.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 13.484622676523578
+                "Value": 13.731527418974004
               },
               {
                 "Name": "smsp__thread_inst_executed_per_inst_executed.ratio",
@@ -208,19 +208,19 @@
           "ValueType": "UnsignedInt"
         }
       ],
-      "DataMovementOverhead": 7083.307,
+      "DataMovementOverhead": 51218.207,
       "ExtraDuration": 0.0,
       "KernelName": "vectorAddition_kernel",
-      "ProfilingOverhead": 26136.887,
-      "SearcherOverhead": 11.446,
+      "ProfilingOverhead": 71170.994,
+      "SearcherOverhead": 13.119,
       "Status": "Ok",
-      "Timestamp": "2025-10-21 09:06:2 UTC",
-      "TotalDuration": 88.8,
-      "TotalOverhead": 124048.337,
-      "ValidationOverhead": 11170.823
+      "Timestamp": "2026-04-21 07:19:6 UTC",
+      "TotalDuration": 89.536,
+      "TotalOverhead": 119152.025,
+      "ValidationOverhead": 10290.98
     },
     {
-      "CompilationOverhead": 11990.976,
+      "CompilationOverhead": 8228.73,
       "ComputationResults": [
         {
           "CompilationData": {
@@ -230,8 +230,8 @@
             "PrivateMemorySize": 0,
             "RegistersCount": 12
           },
-          "CompilationOverhead": 1.487,
-          "Duration": 50.464,
+          "CompilationOverhead": 8216.375,
+          "Duration": 54.304,
           "GlobalSize": {
             "X": 16384,
             "Y": 1,
@@ -243,43 +243,43 @@
             "Y": 1,
             "Z": 1
           },
-          "Overhead": 8704.009,
+          "Overhead": 8216.375,
           "ProfilingData": {
             "Counters": [
               {
                 "Name": "dram__throughput.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 39.08663127413127
+                "Value": 33.9527027027027
               },
               {
                 "Name": "dram__sectors_read.sum",
                 "Type": "Double",
-                "Value": 3988.0
+                "Value": 2804.0
               },
               {
                 "Name": "dram__sectors_write.sum",
                 "Type": "Double",
-                "Value": 47844.0
+                "Value": 42220.0
               },
               {
                 "Name": "lts__t_sectors.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 39.98111152500648
+                "Value": 40.00903975872357
               },
               {
                 "Name": "lts__t_sectors_op_read.sum",
                 "Type": "Double",
-                "Value": 262758.0
+                "Value": 262733.0
               },
               {
                 "Name": "lts__t_sectors_op_write.sum",
                 "Type": "Double",
-                "Value": 132081.0
+                "Value": 131921.0
               },
               {
                 "Name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 6.876442079175196
+                "Value": 6.8574466014642805
               },
               {
                 "Name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.sum",
@@ -289,7 +289,7 @@
               {
                 "Name": "l1tex__data_pipe_lsu_wavefronts_mem_shared.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 2.9702252324114227
+                "Value": 2.972531659349033
               },
               {
                 "Name": "l1tex__data_pipe_lsu_wavefronts_mem_shared_op_ld.sum",
@@ -314,12 +314,12 @@
               {
                 "Name": "sm__warps_active.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 29.65274156367288
+                "Value": 29.613921584835822
               },
               {
                 "Name": "smsp__cycles_active.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 80.56765402242172
+                "Value": 80.80187053231249
               },
               {
                 "Name": "smsp__sass_thread_inst_executed_op_fp16_pred_on.sum",
@@ -369,7 +369,7 @@
               {
                 "Name": "smsp__pipe_fma_cycles_active.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 8.294984925496598
+                "Value": 8.27570721685364
               },
               {
                 "Name": "smsp__inst_executed_pipe_fp64.avg.pct_of_peak_sustained_active",
@@ -384,7 +384,7 @@
               {
                 "Name": "smsp__inst_executed_pipe_lsu.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 7.3732449292487
+                "Value": 7.357581302923734
               },
               {
                 "Name": "smsp__inst_executed_pipe_tex.avg.pct_of_peak_sustained_active",
@@ -394,7 +394,7 @@
               {
                 "Name": "smsp__issue_active.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 13.930562497380702
+                "Value": 13.900547586102372
               },
               {
                 "Name": "smsp__thread_inst_executed_per_inst_executed.ratio",
@@ -418,19 +418,19 @@
           "ValueType": "UnsignedInt"
         }
       ],
-      "DataMovementOverhead": 4432.229,
+      "DataMovementOverhead": 49504.006,
       "ExtraDuration": 0.0,
       "KernelName": "vectorAddition_kernel",
-      "ProfilingOverhead": 24663.287,
-      "SearcherOverhead": 7.876,
+      "ProfilingOverhead": 71627.186,
+      "SearcherOverhead": 12.956,
       "Status": "Ok",
-      "Timestamp": "2025-10-21 09:06:2 UTC",
-      "TotalDuration": 50.464,
-      "TotalOverhead": 46803.032,
-      "ValidationOverhead": 9389.98
+      "Timestamp": "2026-04-21 07:19:6 UTC",
+      "TotalDuration": 54.304,
+      "TotalOverhead": 116185.978,
+      "ValidationOverhead": 10353.404
     },
     {
-      "CompilationOverhead": 12331.284,
+      "CompilationOverhead": 7667.891,
       "ComputationResults": [
         {
           "CompilationData": {
@@ -440,8 +440,8 @@
             "PrivateMemorySize": 0,
             "RegistersCount": 12
           },
-          "CompilationOverhead": 5.857,
-          "Duration": 44.16,
+          "CompilationOverhead": 7656.291,
+          "Duration": 46.976,
           "GlobalSize": {
             "X": 8192,
             "Y": 1,
@@ -453,43 +453,43 @@
             "Y": 1,
             "Z": 1
           },
-          "Overhead": 10524.259,
+          "Overhead": 7656.291,
           "ProfilingData": {
             "Counters": [
               {
                 "Name": "dram__throughput.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 77.16126824817519
+                "Value": 74.02901785714285
               },
               {
                 "Name": "dram__sectors_read.sum",
                 "Type": "Double",
-                "Value": 9988.0
+                "Value": 10716.0
               },
               {
                 "Name": "dram__sectors_write.sum",
                 "Type": "Double",
-                "Value": 44136.0
+                "Value": 42348.0
               },
               {
                 "Name": "lts__t_sectors.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 75.79090811243003
+                "Value": 74.01279219998798
               },
               {
                 "Name": "lts__t_sectors_op_read.sum",
                 "Type": "Double",
-                "Value": 262406.0
+                "Value": 262429.0
               },
               {
                 "Name": "lts__t_sectors_op_write.sum",
                 "Type": "Double",
-                "Value": 131789.0
+                "Value": 131562.0
               },
               {
                 "Name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 13.341394845111079
+                "Value": 13.39659320644564
               },
               {
                 "Name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.sum",
@@ -499,7 +499,7 @@
               {
                 "Name": "l1tex__data_pipe_lsu_wavefronts_mem_shared.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 5.625523615937152
+                "Value": 5.496658525456937
               },
               {
                 "Name": "l1tex__data_pipe_lsu_wavefronts_mem_shared_op_ld.sum",
@@ -524,12 +524,12 @@
               {
                 "Name": "sm__warps_active.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 62.03402019042268
+                "Value": 62.10694250533355
               },
               {
                 "Name": "smsp__cycles_active.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 83.77468720385656
+                "Value": 81.90168818272096
               },
               {
                 "Name": "smsp__sass_thread_inst_executed_op_fp16_pred_on.sum",
@@ -579,7 +579,7 @@
               {
                 "Name": "smsp__pipe_fma_cycles_active.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 15.110430296478834
+                "Value": 15.098760476147563
               },
               {
                 "Name": "smsp__inst_executed_pipe_fp64.avg.pct_of_peak_sustained_active",
@@ -594,7 +594,7 @@
               {
                 "Name": "smsp__inst_executed_pipe_lsu.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 13.430127413661491
+                "Value": 13.422576866044583
               },
               {
                 "Name": "smsp__inst_executed_pipe_tex.avg.pct_of_peak_sustained_active",
@@ -604,7 +604,7 @@
               {
                 "Name": "smsp__issue_active.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 25.426172313272637
+                "Value": 25.414335220337037
               },
               {
                 "Name": "smsp__thread_inst_executed_per_inst_executed.ratio",
@@ -628,19 +628,19 @@
           "ValueType": "UnsignedInt"
         }
       ],
-      "DataMovementOverhead": 5662.28,
+      "DataMovementOverhead": 49704.45,
       "ExtraDuration": 0.0,
       "KernelName": "vectorAddition_kernel",
-      "ProfilingOverhead": 28496.437,
-      "SearcherOverhead": 13.6,
+      "ProfilingOverhead": 71768.721,
+      "SearcherOverhead": 11.549,
       "Status": "Ok",
-      "Timestamp": "2025-10-21 09:06:2 UTC",
-      "TotalDuration": 44.16,
-      "TotalOverhead": 54367.96,
-      "ValidationOverhead": 12737.968
+      "Timestamp": "2026-04-21 07:19:6 UTC",
+      "TotalDuration": 46.976,
+      "TotalOverhead": 115846.954,
+      "ValidationOverhead": 9989.325
     },
     {
-      "CompilationOverhead": 13339.363,
+      "CompilationOverhead": 8048.958,
       "ComputationResults": [
         {
           "CompilationData": {
@@ -650,8 +650,8 @@
             "PrivateMemorySize": 0,
             "RegistersCount": 12
           },
-          "CompilationOverhead": 1.61,
-          "Duration": 55.168,
+          "CompilationOverhead": 8037.038,
+          "Duration": 44.672,
           "GlobalSize": {
             "X": 4096,
             "Y": 1,
@@ -663,43 +663,43 @@
             "Y": 1,
             "Z": 1
           },
-          "Overhead": 9016.448,
+          "Overhead": 8037.038,
           "ProfilingData": {
             "Counters": [
               {
                 "Name": "dram__throughput.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 74.90479390681004
+                "Value": 75.54505813953489
               },
               {
                 "Name": "dram__sectors_read.sum",
                 "Type": "Double",
-                "Value": 10804.0
+                "Value": 11024.0
               },
               {
                 "Name": "dram__sectors_write.sum",
                 "Type": "Double",
-                "Value": 42696.0
+                "Value": 47188.0
               },
               {
                 "Name": "lts__t_sectors.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 74.19294124732737
+                "Value": 69.00203872884207
               },
               {
                 "Name": "lts__t_sectors_op_read.sum",
                 "Type": "Double",
-                "Value": 262530.0
+                "Value": 262425.0
               },
               {
                 "Name": "lts__t_sectors_op_write.sum",
                 "Type": "Double",
-                "Value": 131530.0
+                "Value": 131402.0
               },
               {
                 "Name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 13.119269728149899
+                "Value": 12.945408287226245
               },
               {
                 "Name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.sum",
@@ -709,7 +709,7 @@
               {
                 "Name": "l1tex__data_pipe_lsu_wavefronts_mem_shared.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 5.510116229014206
+                "Value": 5.12936108397826
               },
               {
                 "Name": "l1tex__data_pipe_lsu_wavefronts_mem_shared_op_ld.sum",
@@ -734,12 +734,12 @@
               {
                 "Name": "sm__warps_active.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 63.19421784708599
+                "Value": 62.99654007547011
               },
               {
                 "Name": "smsp__cycles_active.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 83.47831131618597
+                "Value": 77.21611472186741
               },
               {
                 "Name": "smsp__sass_thread_inst_executed_op_fp16_pred_on.sum",
@@ -789,7 +789,7 @@
               {
                 "Name": "smsp__pipe_fma_cycles_active.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 14.847598529919798
+                "Value": 14.94279379157428
               },
               {
                 "Name": "smsp__inst_executed_pipe_fp64.avg.pct_of_peak_sustained_active",
@@ -804,7 +804,7 @@
               {
                 "Name": "smsp__inst_executed_pipe_lsu.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 13.201312154348349
+                "Value": 13.285726955970858
               },
               {
                 "Name": "smsp__inst_executed_pipe_tex.avg.pct_of_peak_sustained_active",
@@ -814,7 +814,7 @@
               {
                 "Name": "smsp__issue_active.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 25.008384775061415
+                "Value": 25.16829901805512
               },
               {
                 "Name": "smsp__thread_inst_executed_per_inst_executed.ratio",
@@ -838,16 +838,16 @@
           "ValueType": "UnsignedInt"
         }
       ],
-      "DataMovementOverhead": 5209.396,
+      "DataMovementOverhead": 49623.594,
       "ExtraDuration": 0.0,
       "KernelName": "vectorAddition_kernel",
-      "ProfilingOverhead": 26105.576,
-      "SearcherOverhead": 4.869,
+      "ProfilingOverhead": 71463.378,
+      "SearcherOverhead": 4.228,
       "Status": "Ok",
-      "Timestamp": "2025-10-21 09:06:3 UTC",
-      "TotalDuration": 55.168,
-      "TotalOverhead": 50775.752,
-      "ValidationOverhead": 10421.013
+      "Timestamp": "2026-04-21 07:19:6 UTC",
+      "TotalDuration": 44.672,
+      "TotalOverhead": 115724.152,
+      "ValidationOverhead": 9776.555
     }
   ]
 }

--- a/Tutorials/03KernelTuning/FullSearchSpace.ktt.json
+++ b/Tutorials/03KernelTuning/FullSearchSpace.ktt.json
@@ -6,11 +6,11 @@
     "KttVersion": "2.2.0",
     "Platform": "NVIDIA CUDA",
     "TimeUnit": "Microseconds",
-    "Timestamp": "2026-04-21 07:19:6 UTC"
+    "Timestamp": "2026-04-28 10:54:52 UTC"
   },
   "Results": [
     {
-      "CompilationOverhead": 9265.11,
+      "CompilationOverhead": 8395.116,
       "ComputationResults": [
         {
           "CompilationData": {
@@ -20,8 +20,8 @@
             "PrivateMemorySize": 0,
             "RegistersCount": 12
           },
-          "CompilationOverhead": 9253.058,
-          "Duration": 89.536,
+          "CompilationOverhead": 8372.579,
+          "Duration": 101.12,
           "GlobalSize": {
             "X": 32768,
             "Y": 1,
@@ -33,43 +33,43 @@
             "Y": 1,
             "Z": 1
           },
-          "Overhead": 9253.058,
+          "Overhead": 8372.579,
           "ProfilingData": {
             "Counters": [
               {
                 "Name": "dram__throughput.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 1.1848341232227488
+                "Value": 95.57326575067025
               },
               {
                 "Name": "dram__sectors_read.sum",
                 "Type": "Double",
-                "Value": 408.0
+                "Value": 262372.0
               },
               {
                 "Name": "dram__sectors_write.sum",
                 "Type": "Double",
-                "Value": 2792.0
+                "Value": 102672.0
               },
               {
                 "Name": "lts__t_sectors.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 19.631978939002583
+                "Value": 10.73259040846414
               },
               {
                 "Name": "lts__t_sectors_op_read.sum",
                 "Type": "Double",
-                "Value": 263574.0
+                "Value": 263790.0
               },
               {
                 "Name": "lts__t_sectors_op_write.sum",
                 "Type": "Double",
-                "Value": 131521.0
+                "Value": 132098.0
               },
               {
                 "Name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 6.310907732248645
+                "Value": 1.6112563723375093
               },
               {
                 "Name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.sum",
@@ -79,7 +79,7 @@
               {
                 "Name": "l1tex__data_pipe_lsu_wavefronts_mem_shared.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 1.4581961231064988
+                "Value": 0.7939846359320694
               },
               {
                 "Name": "l1tex__data_pipe_lsu_wavefronts_mem_shared_op_ld.sum",
@@ -104,12 +104,12 @@
               {
                 "Name": "sm__warps_active.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 24.798153861758866
+                "Value": 45.421230921915026
               },
               {
                 "Name": "smsp__cycles_active.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 40.002347407394225
+                "Value": 97.82301179152476
               },
               {
                 "Name": "smsp__sass_thread_inst_executed_op_fp16_pred_on.sum",
@@ -159,7 +159,7 @@
               {
                 "Name": "smsp__pipe_fma_cycles_active.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 8.202316844134899
+                "Value": 1.826085836499523
               },
               {
                 "Name": "smsp__inst_executed_pipe_fp64.avg.pct_of_peak_sustained_active",
@@ -174,7 +174,7 @@
               {
                 "Name": "smsp__inst_executed_pipe_lsu.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 7.2905527680955995
+                "Value": 1.6233085066408863
               },
               {
                 "Name": "smsp__inst_executed_pipe_tex.avg.pct_of_peak_sustained_active",
@@ -184,7 +184,7 @@
               {
                 "Name": "smsp__issue_active.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 13.731527418974004
+                "Value": 3.0578159991102716
               },
               {
                 "Name": "smsp__thread_inst_executed_per_inst_executed.ratio",
@@ -208,19 +208,19 @@
           "ValueType": "UnsignedInt"
         }
       ],
-      "DataMovementOverhead": 51218.207,
+      "DataMovementOverhead": 10930.775,
       "ExtraDuration": 0.0,
       "KernelName": "vectorAddition_kernel",
-      "ProfilingOverhead": 71170.994,
-      "SearcherOverhead": 13.119,
+      "ProfilingOverhead": 74621.108,
+      "SearcherOverhead": 30.814,
       "Status": "Ok",
-      "Timestamp": "2026-04-21 07:19:6 UTC",
-      "TotalDuration": 89.536,
-      "TotalOverhead": 119152.025,
-      "ValidationOverhead": 10290.98
+      "Timestamp": "2026-04-28 10:54:52 UTC",
+      "TotalDuration": 101.12,
+      "TotalOverhead": 89370.161,
+      "ValidationOverhead": 15718.628
     },
     {
-      "CompilationOverhead": 8228.73,
+      "CompilationOverhead": 11661.164,
       "ComputationResults": [
         {
           "CompilationData": {
@@ -230,8 +230,8 @@
             "PrivateMemorySize": 0,
             "RegistersCount": 12
           },
-          "CompilationOverhead": 8216.375,
-          "Duration": 54.304,
+          "CompilationOverhead": 11642.129,
+          "Duration": 161.056,
           "GlobalSize": {
             "X": 16384,
             "Y": 1,
@@ -243,43 +243,43 @@
             "Y": 1,
             "Z": 1
           },
-          "Overhead": 8216.375,
+          "Overhead": 11642.129,
           "ProfilingData": {
             "Counters": [
               {
                 "Name": "dram__throughput.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 33.9527027027027
+                "Value": 94.76897620643432
               },
               {
                 "Name": "dram__sectors_read.sum",
                 "Type": "Double",
-                "Value": 2804.0
+                "Value": 262284.0
               },
               {
                 "Name": "dram__sectors_write.sum",
                 "Type": "Double",
-                "Value": 42220.0
+                "Value": 99688.0
               },
               {
                 "Name": "lts__t_sectors.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 40.00903975872357
+                "Value": 10.714982400166463
               },
               {
                 "Name": "lts__t_sectors_op_read.sum",
                 "Type": "Double",
-                "Value": 262733.0
+                "Value": 263596.0
               },
               {
                 "Name": "lts__t_sectors_op_write.sum",
                 "Type": "Double",
-                "Value": 131921.0
+                "Value": 131752.0
               },
               {
                 "Name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 6.8574466014642805
+                "Value": 1.623314135906487
               },
               {
                 "Name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.sum",
@@ -289,7 +289,7 @@
               {
                 "Name": "l1tex__data_pipe_lsu_wavefronts_mem_shared.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 2.972531659349033
+                "Value": 0.7940692949533174
               },
               {
                 "Name": "l1tex__data_pipe_lsu_wavefronts_mem_shared_op_ld.sum",
@@ -314,12 +314,12 @@
               {
                 "Name": "sm__warps_active.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 29.613921584835822
+                "Value": 93.28206323665925
               },
               {
                 "Name": "smsp__cycles_active.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 80.80187053231249
+                "Value": 98.97179682411054
               },
               {
                 "Name": "smsp__sass_thread_inst_executed_op_fp16_pred_on.sum",
@@ -369,7 +369,7 @@
               {
                 "Name": "smsp__pipe_fma_cycles_active.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 8.27570721685364
+                "Value": 1.8051621235174973
               },
               {
                 "Name": "smsp__inst_executed_pipe_fp64.avg.pct_of_peak_sustained_active",
@@ -384,7 +384,7 @@
               {
                 "Name": "smsp__inst_executed_pipe_lsu.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 7.357581302923734
+                "Value": 1.6046375238887731
               },
               {
                 "Name": "smsp__inst_executed_pipe_tex.avg.pct_of_peak_sustained_active",
@@ -394,7 +394,7 @@
               {
                 "Name": "smsp__issue_active.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 13.900547586102372
+                "Value": 3.031735578085812
               },
               {
                 "Name": "smsp__thread_inst_executed_per_inst_executed.ratio",
@@ -418,19 +418,19 @@
           "ValueType": "UnsignedInt"
         }
       ],
-      "DataMovementOverhead": 49504.006,
+      "DataMovementOverhead": 8536.944,
       "ExtraDuration": 0.0,
       "KernelName": "vectorAddition_kernel",
-      "ProfilingOverhead": 71627.186,
-      "SearcherOverhead": 12.956,
+      "ProfilingOverhead": 78967.904,
+      "SearcherOverhead": 26.07,
       "Status": "Ok",
-      "Timestamp": "2026-04-21 07:19:6 UTC",
-      "TotalDuration": 54.304,
-      "TotalOverhead": 116185.978,
-      "ValidationOverhead": 10353.404
+      "Timestamp": "2026-04-28 10:54:52 UTC",
+      "TotalDuration": 161.056,
+      "TotalOverhead": 94976.553,
+      "ValidationOverhead": 15792.062
     },
     {
-      "CompilationOverhead": 7667.891,
+      "CompilationOverhead": 12156.362,
       "ComputationResults": [
         {
           "CompilationData": {
@@ -440,8 +440,8 @@
             "PrivateMemorySize": 0,
             "RegistersCount": 12
           },
-          "CompilationOverhead": 7656.291,
-          "Duration": 46.976,
+          "CompilationOverhead": 12132.711,
+          "Duration": 164.992,
           "GlobalSize": {
             "X": 8192,
             "Y": 1,
@@ -453,43 +453,43 @@
             "Y": 1,
             "Z": 1
           },
-          "Overhead": 7656.291,
+          "Overhead": 12132.711,
           "ProfilingData": {
             "Counters": [
               {
                 "Name": "dram__throughput.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 74.02901785714285
+                "Value": 95.14514514514515
               },
               {
                 "Name": "dram__sectors_read.sum",
                 "Type": "Double",
-                "Value": 10716.0
+                "Value": 262276.0
               },
               {
                 "Name": "dram__sectors_write.sum",
                 "Type": "Double",
-                "Value": 42348.0
+                "Value": 102716.0
               },
               {
                 "Name": "lts__t_sectors.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 74.01279219998798
+                "Value": 10.650956175126938
               },
               {
                 "Name": "lts__t_sectors_op_read.sum",
                 "Type": "Double",
-                "Value": 262429.0
+                "Value": 263548.0
               },
               {
                 "Name": "lts__t_sectors_op_write.sum",
                 "Type": "Double",
-                "Value": 131562.0
+                "Value": 131354.0
               },
               {
                 "Name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 13.39659320644564
+                "Value": 1.630882853208847
               },
               {
                 "Name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.sum",
@@ -499,7 +499,7 @@
               {
                 "Name": "l1tex__data_pipe_lsu_wavefronts_mem_shared.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 5.496658525456937
+                "Value": 0.7901859522068683
               },
               {
                 "Name": "l1tex__data_pipe_lsu_wavefronts_mem_shared_op_ld.sum",
@@ -524,12 +524,12 @@
               {
                 "Name": "sm__warps_active.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 62.10694250533355
+                "Value": 92.59109117964688
               },
               {
                 "Name": "smsp__cycles_active.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 81.90168818272096
+                "Value": 97.85590801934566
               },
               {
                 "Name": "smsp__sass_thread_inst_executed_op_fp16_pred_on.sum",
@@ -579,7 +579,7 @@
               {
                 "Name": "smsp__pipe_fma_cycles_active.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 15.098760476147563
+                "Value": 1.8164302660259586
               },
               {
                 "Name": "smsp__inst_executed_pipe_fp64.avg.pct_of_peak_sustained_active",
@@ -594,7 +594,7 @@
               {
                 "Name": "smsp__inst_executed_pipe_lsu.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 13.422576866044583
+                "Value": 1.614998967769329
               },
               {
                 "Name": "smsp__inst_executed_pipe_tex.avg.pct_of_peak_sustained_active",
@@ -604,7 +604,7 @@
               {
                 "Name": "smsp__issue_active.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 25.414335220337037
+                "Value": 3.057669935941323
               },
               {
                 "Name": "smsp__thread_inst_executed_per_inst_executed.ratio",
@@ -628,19 +628,19 @@
           "ValueType": "UnsignedInt"
         }
       ],
-      "DataMovementOverhead": 49704.45,
+      "DataMovementOverhead": 8950.447,
       "ExtraDuration": 0.0,
       "KernelName": "vectorAddition_kernel",
-      "ProfilingOverhead": 71768.721,
-      "SearcherOverhead": 11.549,
+      "ProfilingOverhead": 81066.512,
+      "SearcherOverhead": 22.188,
       "Status": "Ok",
-      "Timestamp": "2026-04-21 07:19:6 UTC",
-      "TotalDuration": 46.976,
-      "TotalOverhead": 115846.954,
-      "ValidationOverhead": 9989.325
+      "Timestamp": "2026-04-28 10:54:52 UTC",
+      "TotalDuration": 164.992,
+      "TotalOverhead": 97738.071,
+      "ValidationOverhead": 16802.713
     },
     {
-      "CompilationOverhead": 8048.958,
+      "CompilationOverhead": 12184.085,
       "ComputationResults": [
         {
           "CompilationData": {
@@ -650,8 +650,8 @@
             "PrivateMemorySize": 0,
             "RegistersCount": 12
           },
-          "CompilationOverhead": 8037.038,
-          "Duration": 44.672,
+          "CompilationOverhead": 12157.771,
+          "Duration": 166.976,
           "GlobalSize": {
             "X": 4096,
             "Y": 1,
@@ -663,43 +663,43 @@
             "Y": 1,
             "Z": 1
           },
-          "Overhead": 8037.038,
+          "Overhead": 12157.771,
           "ProfilingData": {
             "Counters": [
               {
                 "Name": "dram__throughput.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 75.54505813953489
+                "Value": 95.30516431924883
               },
               {
                 "Name": "dram__sectors_read.sum",
                 "Type": "Double",
-                "Value": 11024.0
+                "Value": 262400.0
               },
               {
                 "Name": "dram__sectors_write.sum",
                 "Type": "Double",
-                "Value": 47188.0
+                "Value": 101376.0
               },
               {
                 "Name": "lts__t_sectors.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 69.00203872884207
+                "Value": 10.705474254742548
               },
               {
                 "Name": "lts__t_sectors_op_read.sum",
                 "Type": "Double",
-                "Value": 262425.0
+                "Value": 263729.0
               },
               {
                 "Name": "lts__t_sectors_op_write.sum",
                 "Type": "Double",
-                "Value": 131402.0
+                "Value": 131167.0
               },
               {
                 "Name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 12.945408287226245
+                "Value": 1.6203665357322026
               },
               {
                 "Name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.sum",
@@ -709,7 +709,7 @@
               {
                 "Name": "l1tex__data_pipe_lsu_wavefronts_mem_shared.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 5.12936108397826
+                "Value": 0.7944497136218257
               },
               {
                 "Name": "l1tex__data_pipe_lsu_wavefronts_mem_shared_op_ld.sum",
@@ -734,12 +734,12 @@
               {
                 "Name": "sm__warps_active.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 62.99654007547011
+                "Value": 92.22882742652996
               },
               {
                 "Name": "smsp__cycles_active.avg.pct_of_peak_sustained_elapsed",
                 "Type": "Double",
-                "Value": 77.21611472186741
+                "Value": 98.0899676478974
               },
               {
                 "Name": "smsp__sass_thread_inst_executed_op_fp16_pred_on.sum",
@@ -789,7 +789,7 @@
               {
                 "Name": "smsp__pipe_fma_cycles_active.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 14.94279379157428
+                "Value": 1.8223434497876767
               },
               {
                 "Name": "smsp__inst_executed_pipe_fp64.avg.pct_of_peak_sustained_active",
@@ -804,7 +804,7 @@
               {
                 "Name": "smsp__inst_executed_pipe_lsu.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 13.285726955970858
+                "Value": 1.619838873784877
               },
               {
                 "Name": "smsp__inst_executed_pipe_tex.avg.pct_of_peak_sustained_active",
@@ -814,7 +814,7 @@
               {
                 "Name": "smsp__issue_active.avg.pct_of_peak_sustained_active",
                 "Type": "Double",
-                "Value": 25.16829901805512
+                "Value": 3.068600556943197
               },
               {
                 "Name": "smsp__thread_inst_executed_per_inst_executed.ratio",
@@ -838,16 +838,16 @@
           "ValueType": "UnsignedInt"
         }
       ],
-      "DataMovementOverhead": 49623.594,
+      "DataMovementOverhead": 9070.044,
       "ExtraDuration": 0.0,
       "KernelName": "vectorAddition_kernel",
-      "ProfilingOverhead": 71463.378,
-      "SearcherOverhead": 4.228,
+      "ProfilingOverhead": 81109.348,
+      "SearcherOverhead": 7.63,
       "Status": "Ok",
-      "Timestamp": "2026-04-21 07:19:6 UTC",
-      "TotalDuration": 44.672,
-      "TotalOverhead": 115724.152,
-      "ValidationOverhead": 9776.555
+      "Timestamp": "2026-04-28 10:54:52 UTC",
+      "TotalDuration": 166.976,
+      "TotalOverhead": 97823.054,
+      "ValidationOverhead": 16649.191
     }
   ]
 }

--- a/Tutorials/03KernelTuning/FullSearchSpace.t4.json
+++ b/Tutorials/03KernelTuning/FullSearchSpace.t4.json
@@ -5,7 +5,7 @@
     "compute_api": "CUDA",
     "device": "NVIDIA RTX 500 Ada Generation Laptop GPU",
     "platform": "NVIDIA CUDA",
-    "timestamp": "2026-04-21 07:24:11 UTC",
+    "timestamp": "2026-04-28 10:48:40 UTC",
     "timeunit": "microseconds"
   },
   "results": [
@@ -36,49 +36,49 @@
         {
           "name": "time",
           "unit": "",
-          "value": 90.848
+          "value": 101.504
         },
         {
           "name": "dram__throughput.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 0.9251062322946176
+          "value": 95.65620782726046
         },
         {
           "name": "dram__sectors_read.sum",
           "type": "Double",
           "unit": "",
-          "value": 172.0
+          "value": 262388.0
         },
         {
           "name": "dram__sectors_write.sum",
           "type": "Double",
           "unit": "",
-          "value": 2336.0
+          "value": 100524.0
         },
         {
           "name": "lts__t_sectors.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 19.575410004993778
+          "value": 10.772606910007882
         },
         {
           "name": "lts__t_sectors_op_read.sum",
           "type": "Double",
           "unit": "",
-          "value": 263595.0
+          "value": 263756.0
         },
         {
           "name": "lts__t_sectors_op_write.sum",
           "type": "Double",
           "unit": "",
-          "value": 131401.0
+          "value": 131866.0
         },
         {
           "name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 6.3122753992127
+          "value": 1.6004974202187348
         },
         {
           "name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.sum",
@@ -90,7 +90,7 @@
           "name": "l1tex__data_pipe_lsu_wavefronts_mem_shared.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 1.453755594439101
+          "value": 0.7990823039165958
         },
         {
           "name": "l1tex__data_pipe_lsu_wavefronts_mem_shared_op_ld.sum",
@@ -120,13 +120,13 @@
           "name": "sm__warps_active.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 24.76481028788391
+          "value": 45.4068218915042
         },
         {
           "name": "smsp__cycles_active.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 40.15878934740712
+          "value": 98.76841878857874
         },
         {
           "name": "smsp__sass_thread_inst_executed_op_fp16_pred_on.sum",
@@ -186,7 +186,7 @@
           "name": "smsp__pipe_fma_cycles_active.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 8.14520728411616
+          "value": 1.8202740827275095
         },
         {
           "name": "smsp__inst_executed_pipe_fp64.avg.pct_of_peak_sustained_active",
@@ -204,7 +204,7 @@
           "name": "smsp__inst_executed_pipe_lsu.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 7.240036953618789
+          "value": 1.6180927339276168
         },
         {
           "name": "smsp__inst_executed_pipe_tex.avg.pct_of_peak_sustained_active",
@@ -216,7 +216,7 @@
           "name": "smsp__issue_active.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 13.636520559938466
+          "value": 3.0480342886728695
         },
         {
           "name": "smsp__thread_inst_executed_per_inst_executed.ratio",
@@ -235,19 +235,19 @@
         "time"
       ],
       "times": {
-        "compilation_time": 9894.26,
-        "data": 52674.913,
-        "framework": 122735.632,
-        "kernel_overhead": 9894.26,
-        "profiling_overhead": 69182.464,
-        "profiling_runs": 3765.809,
+        "compilation_time": 8515.104,
+        "data": 10149.588,
+        "framework": 82902.779,
+        "kernel_overhead": 8515.104,
+        "profiling_overhead": 64395.232,
+        "profiling_runs": 3744.197,
         "runtimes": [
-          90.848
+          101.504
         ],
-        "search_algorithm": 15.202,
-        "validation": 10504.756
+        "search_algorithm": 20.947,
+        "validation": 14668.742
       },
-      "timestamp": "2026-04-21 07:24:11 UTC"
+      "timestamp": "2026-04-28 10:48:39 UTC"
     },
     {
       "compilation_data": {
@@ -276,49 +276,49 @@
         {
           "name": "time",
           "unit": "",
-          "value": 61.312
+          "value": 157.472
         },
         {
           "name": "dram__throughput.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 1.2397442084942085
+          "value": 95.12336079354405
         },
         {
           "name": "dram__sectors_read.sum",
           "type": "Double",
           "unit": "",
-          "value": 40.0
+          "value": 262920.0
         },
         {
           "name": "dram__sectors_write.sum",
           "type": "Double",
           "unit": "",
-          "value": 1604.0
+          "value": 99188.0
         },
         {
           "name": "lts__t_sectors.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 39.971481733716004
+          "value": 10.74062927051474
         },
         {
           "name": "lts__t_sectors_op_read.sum",
           "type": "Double",
           "unit": "",
-          "value": 262870.0
+          "value": 264229.0
         },
         {
           "name": "lts__t_sectors_op_write.sum",
           "type": "Double",
           "unit": "",
-          "value": 131407.0
+          "value": 131758.0
         },
         {
           "name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 6.954417874178265
+          "value": 1.6100510265500203
         },
         {
           "name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.sum",
@@ -330,7 +330,7 @@
           "name": "l1tex__data_pipe_lsu_wavefronts_mem_shared.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 2.9704837189063746
+          "value": 0.7958745098648801
         },
         {
           "name": "l1tex__data_pipe_lsu_wavefronts_mem_shared_op_ld.sum",
@@ -360,13 +360,13 @@
           "name": "sm__warps_active.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 30.184365488248538
+          "value": 93.47976851749488
         },
         {
           "name": "smsp__cycles_active.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 80.53294292552035
+          "value": 99.9504885806775
         },
         {
           "name": "smsp__sass_thread_inst_executed_op_fp16_pred_on.sum",
@@ -426,7 +426,7 @@
           "name": "smsp__pipe_fma_cycles_active.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 8.299985929365414
+          "value": 1.7914528198977764
         },
         {
           "name": "smsp__inst_executed_pipe_fp64.avg.pct_of_peak_sustained_active",
@@ -444,7 +444,7 @@
           "name": "smsp__inst_executed_pipe_lsu.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 7.37706486562544
+          "value": 1.5925375076530424
         },
         {
           "name": "smsp__inst_executed_pipe_tex.avg.pct_of_peak_sustained_active",
@@ -456,7 +456,7 @@
           "name": "smsp__issue_active.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 13.937779653862389
+          "value": 3.008728508149131
         },
         {
           "name": "smsp__thread_inst_executed_per_inst_executed.ratio",
@@ -475,19 +475,19 @@
         "time"
       ],
       "times": {
-        "compilation_time": 8531.338,
-        "data": 50647.054,
-        "framework": 118997.318,
-        "kernel_overhead": 8531.338,
-        "profiling_overhead": 68602.072,
-        "profiling_runs": 3575.468,
+        "compilation_time": 6896.793,
+        "data": 7948.183,
+        "framework": 78033.57,
+        "kernel_overhead": 6896.793,
+        "profiling_overhead": 63342.959,
+        "profiling_runs": 3977.604,
         "runtimes": [
-          61.312
+          157.472
         ],
-        "search_algorithm": 10.609,
-        "validation": 10682.389
+        "search_algorithm": 12.192,
+        "validation": 13614.287
       },
-      "timestamp": "2026-04-21 07:24:11 UTC"
+      "timestamp": "2026-04-28 10:48:39 UTC"
     },
     {
       "compilation_data": {
@@ -516,49 +516,49 @@
         {
           "name": "time",
           "unit": "",
-          "value": 37.28
+          "value": 156.416
         },
         {
           "name": "dram__throughput.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 59.375
+          "value": 95.29768957345972
         },
         {
           "name": "dram__sectors_read.sum",
           "type": "Double",
           "unit": "",
-          "value": 8052.0
+          "value": 262264.0
         },
         {
           "name": "dram__sectors_write.sum",
           "type": "Double",
           "unit": "",
-          "value": 35876.0
+          "value": 98068.0
         },
         {
           "name": "lts__t_sectors.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 71.74489409433907
+          "value": 10.791834540862254
         },
         {
           "name": "lts__t_sectors_op_read.sum",
           "type": "Double",
           "unit": "",
-          "value": 262412.0
+          "value": 263627.0
         },
         {
           "name": "lts__t_sectors_op_write.sum",
           "type": "Double",
           "unit": "",
-          "value": 131452.0
+          "value": 131377.0
         },
         {
           "name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 12.70998747153945
+          "value": 1.6251892429414396
         },
         {
           "name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.sum",
@@ -570,7 +570,7 @@
           "name": "l1tex__data_pipe_lsu_wavefronts_mem_shared.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 5.328268702925604
+          "value": 0.8013256304863711
         },
         {
           "name": "l1tex__data_pipe_lsu_wavefronts_mem_shared_op_ld.sum",
@@ -600,13 +600,13 @@
           "name": "sm__warps_active.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 63.523824277027664
+          "value": 92.85569613504228
         },
         {
           "name": "smsp__cycles_active.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 79.16661246471452
+          "value": 97.91596767504055
         },
         {
           "name": "smsp__sass_thread_inst_executed_op_fp16_pred_on.sum",
@@ -666,7 +666,7 @@
           "name": "smsp__pipe_fma_cycles_active.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 15.14068668329013
+          "value": 1.8409700341776696
         },
         {
           "name": "smsp__inst_executed_pipe_fp64.avg.pct_of_peak_sustained_active",
@@ -684,7 +684,7 @@
           "name": "smsp__inst_executed_pipe_lsu.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 13.46089857084759
+          "value": 1.636761908222727
         },
         {
           "name": "smsp__inst_executed_pipe_tex.avg.pct_of_peak_sustained_active",
@@ -696,7 +696,7 @@
           "name": "smsp__issue_active.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 25.48442885252905
+          "value": 3.0988923398101638
         },
         {
           "name": "smsp__thread_inst_executed_per_inst_executed.ratio",
@@ -715,19 +715,19 @@
         "time"
       ],
       "times": {
-        "compilation_time": 8168.616,
-        "data": 49589.34,
-        "framework": 116322.867,
-        "kernel_overhead": 8168.616,
-        "profiling_overhead": 67884.65,
-        "profiling_runs": 3521.295,
+        "compilation_time": 6690.859,
+        "data": 7616.07,
+        "framework": 76743.471,
+        "kernel_overhead": 6690.859,
+        "profiling_overhead": 62440.639,
+        "profiling_runs": 3945.333,
         "runtimes": [
-          37.28
+          156.416
         ],
-        "search_algorithm": 11.733,
-        "validation": 10375.416
+        "search_algorithm": 11.395,
+        "validation": 13465.784
       },
-      "timestamp": "2026-04-21 07:24:11 UTC"
+      "timestamp": "2026-04-28 10:48:39 UTC"
     },
     {
       "compilation_data": {
@@ -756,49 +756,49 @@
         {
           "name": "time",
           "unit": "",
-          "value": 47.232
+          "value": 156.256
         },
         {
           "name": "dram__throughput.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 72.0936433447099
+          "value": 95.05679912810194
         },
         {
           "name": "dram__sectors_read.sum",
           "type": "Double",
           "unit": "",
-          "value": 9836.0
+          "value": 262280.0
         },
         {
           "name": "dram__sectors_write.sum",
           "type": "Double",
           "unit": "",
-          "value": 44240.0
+          "value": 100548.0
         },
         {
           "name": "lts__t_sectors.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 70.75498462952854
+          "value": 10.700314090761399
         },
         {
           "name": "lts__t_sectors_op_read.sum",
           "type": "Double",
           "unit": "",
-          "value": 262415.0
+          "value": 263651.0
         },
         {
           "name": "lts__t_sectors_op_write.sum",
           "type": "Double",
           "unit": "",
-          "value": 131492.0
+          "value": 131397.0
         },
         {
           "name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 13.212130742355791
+          "value": 1.6254629404569034
         },
         {
           "name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.sum",
@@ -810,7 +810,7 @@
           "name": "l1tex__data_pipe_lsu_wavefronts_mem_shared.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 5.247178488617876
+          "value": 0.7946207897320096
         },
         {
           "name": "l1tex__data_pipe_lsu_wavefronts_mem_shared_op_ld.sum",
@@ -840,13 +840,13 @@
           "name": "sm__warps_active.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 63.19614965388448
+          "value": 92.49127444667889
         },
         {
           "name": "smsp__cycles_active.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 79.40737051792829
+          "value": 98.01879512906768
         },
         {
           "name": "smsp__sass_thread_inst_executed_op_fp16_pred_on.sum",
@@ -906,7 +906,7 @@
           "name": "smsp__pipe_fma_cycles_active.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 14.868937535479173
+          "value": 1.8237934245144485
         },
         {
           "name": "smsp__inst_executed_pipe_fp64.avg.pct_of_peak_sustained_active",
@@ -924,7 +924,7 @@
           "name": "smsp__inst_executed_pipe_lsu.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 13.21584748215076
+          "value": 1.6213641244736399
         },
         {
           "name": "smsp__inst_executed_pipe_tex.avg.pct_of_peak_sustained_active",
@@ -936,7 +936,7 @@
           "name": "smsp__issue_active.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 25.035920300792817
+          "value": 3.071489970939097
         },
         {
           "name": "smsp__thread_inst_executed_per_inst_executed.ratio",
@@ -955,19 +955,19 @@
         "time"
       ],
       "times": {
-        "compilation_time": 8263.589,
-        "data": 49852.799,
-        "framework": 117093.403,
-        "kernel_overhead": 8263.589,
-        "profiling_overhead": 68183.775,
-        "profiling_runs": 3554.769,
+        "compilation_time": 6780.495,
+        "data": 7756.813,
+        "framework": 76523.403,
+        "kernel_overhead": 6780.495,
+        "profiling_overhead": 62196.669,
+        "profiling_runs": 3814.416,
         "runtimes": [
-          47.232
+          156.256
         ],
-        "search_algorithm": 4.079,
-        "validation": 10471.088
+        "search_algorithm": 5.044,
+        "validation": 12283.591
       },
-      "timestamp": "2026-04-21 07:24:11 UTC"
+      "timestamp": "2026-04-28 10:48:40 UTC"
     }
   ],
   "schema_version": "1.0.0"

--- a/Tutorials/03KernelTuning/FullSearchSpace.t4.json
+++ b/Tutorials/03KernelTuning/FullSearchSpace.t4.json
@@ -5,7 +5,7 @@
     "compute_api": "CUDA",
     "device": "NVIDIA RTX 500 Ada Generation Laptop GPU",
     "platform": "NVIDIA CUDA",
-    "timestamp": "2026-03-13 09:44:4 UTC",
+    "timestamp": "2026-04-21 07:24:11 UTC",
     "timeunit": "microseconds"
   },
   "results": [
@@ -36,49 +36,49 @@
         {
           "name": "time",
           "unit": "",
-          "value": 89.44
+          "value": 90.848
         },
         {
           "name": "dram__throughput.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 19.12216730954677
+          "value": 0.9251062322946176
         },
         {
           "name": "dram__sectors_read.sum",
           "type": "Double",
           "unit": "",
-          "value": 1696.0
+          "value": 172.0
         },
         {
           "name": "dram__sectors_write.sum",
           "type": "Double",
           "unit": "",
-          "value": 49068.0
+          "value": 2336.0
         },
         {
           "name": "lts__t_sectors.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 20.021818505655002
+          "value": 19.575410004993778
         },
         {
           "name": "lts__t_sectors_op_read.sum",
           "type": "Double",
           "unit": "",
-          "value": 263544.0
+          "value": 263595.0
         },
         {
           "name": "lts__t_sectors_op_write.sum",
           "type": "Double",
           "unit": "",
-          "value": 132012.0
+          "value": 131401.0
         },
         {
           "name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 6.427757366282913
+          "value": 6.3122753992127
         },
         {
           "name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.sum",
@@ -90,7 +90,7 @@
           "name": "l1tex__data_pipe_lsu_wavefronts_mem_shared.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 1.4854734765374251
+          "value": 1.453755594439101
         },
         {
           "name": "l1tex__data_pipe_lsu_wavefronts_mem_shared_op_ld.sum",
@@ -120,13 +120,13 @@
           "name": "sm__warps_active.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 25.2548705608268
+          "value": 24.76481028788391
         },
         {
           "name": "smsp__cycles_active.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 40.84136332809888
+          "value": 40.15878934740712
         },
         {
           "name": "smsp__sass_thread_inst_executed_op_fp16_pred_on.sum",
@@ -186,7 +186,7 @@
           "name": "smsp__pipe_fma_cycles_active.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 8.183513926905666
+          "value": 8.14520728411616
         },
         {
           "name": "smsp__inst_executed_pipe_fp64.avg.pct_of_peak_sustained_active",
@@ -204,7 +204,7 @@
           "name": "smsp__inst_executed_pipe_lsu.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 7.274357932686437
+          "value": 7.240036953618789
         },
         {
           "name": "smsp__inst_executed_pipe_tex.avg.pct_of_peak_sustained_active",
@@ -216,7 +216,7 @@
           "name": "smsp__issue_active.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 13.701274699806198
+          "value": 13.636520559938466
         },
         {
           "name": "smsp__thread_inst_executed_per_inst_executed.ratio",
@@ -235,19 +235,19 @@
         "time"
       ],
       "times": {
-        "compilation_time": 15061.987,
-        "data": 6837.891,
-        "framework": 40386.628,
-        "kernel_overhead": 8584.186,
-        "profiling_overhead": 3889.532,
-        "profiling_runs": 21075.019,
+        "compilation_time": 9894.26,
+        "data": 52674.913,
+        "framework": 122735.632,
+        "kernel_overhead": 9894.26,
+        "profiling_overhead": 69182.464,
+        "profiling_runs": 3765.809,
         "runtimes": [
-          89.44
+          90.848
         ],
-        "search_algorithm": 12.432,
-        "validation": 9727.423
+        "search_algorithm": 15.202,
+        "validation": 10504.756
       },
-      "timestamp": "2026-03-13 09:44:4 UTC"
+      "timestamp": "2026-04-21 07:24:11 UTC"
     },
     {
       "compilation_data": {
@@ -276,49 +276,49 @@
         {
           "name": "time",
           "unit": "",
-          "value": 54.336
+          "value": 61.312
         },
         {
           "name": "dram__throughput.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 40.05379593810445
+          "value": 1.2397442084942085
         },
         {
           "name": "dram__sectors_read.sum",
           "type": "Double",
           "unit": "",
-          "value": 3576.0
+          "value": 40.0
         },
         {
           "name": "dram__sectors_write.sum",
           "type": "Double",
           "unit": "",
-          "value": 49436.0
+          "value": 1604.0
         },
         {
           "name": "lts__t_sectors.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 40.105867823656546
+          "value": 39.971481733716004
         },
         {
           "name": "lts__t_sectors_op_read.sum",
           "type": "Double",
           "unit": "",
-          "value": 262809.0
+          "value": 262870.0
         },
         {
           "name": "lts__t_sectors_op_write.sum",
           "type": "Double",
           "unit": "",
-          "value": 131947.0
+          "value": 131407.0
         },
         {
           "name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 6.901737439945743
+          "value": 6.954417874178265
         },
         {
           "name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.sum",
@@ -330,7 +330,7 @@
           "name": "l1tex__data_pipe_lsu_wavefronts_mem_shared.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 2.97997104422667
+          "value": 2.9704837189063746
         },
         {
           "name": "l1tex__data_pipe_lsu_wavefronts_mem_shared_op_ld.sum",
@@ -360,13 +360,13 @@
           "name": "sm__warps_active.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 29.65983910408843
+          "value": 30.184365488248538
         },
         {
           "name": "smsp__cycles_active.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 81.35844773773927
+          "value": 80.53294292552035
         },
         {
           "name": "smsp__sass_thread_inst_executed_op_fp16_pred_on.sum",
@@ -426,7 +426,7 @@
           "name": "smsp__pipe_fma_cycles_active.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 8.242345387559466
+          "value": 8.299985929365414
         },
         {
           "name": "smsp__inst_executed_pipe_fp64.avg.pct_of_peak_sustained_active",
@@ -444,7 +444,7 @@
           "name": "smsp__inst_executed_pipe_lsu.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 7.325535644024753
+          "value": 7.37706486562544
         },
         {
           "name": "smsp__inst_executed_pipe_tex.avg.pct_of_peak_sustained_active",
@@ -456,7 +456,7 @@
           "name": "smsp__issue_active.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 13.839641011195766
+          "value": 13.937779653862389
         },
         {
           "name": "smsp__thread_inst_executed_per_inst_executed.ratio",
@@ -475,19 +475,19 @@
         "time"
       ],
       "times": {
-        "compilation_time": 12324.712,
-        "data": 4618.838,
-        "framework": 38430.715,
-        "kernel_overhead": 8863.657,
-        "profiling_overhead": 3822.415,
-        "profiling_runs": 21125.805,
+        "compilation_time": 8531.338,
+        "data": 50647.054,
+        "framework": 118997.318,
+        "kernel_overhead": 8531.338,
+        "profiling_overhead": 68602.072,
+        "profiling_runs": 3575.468,
         "runtimes": [
-          54.336
+          61.312
         ],
-        "search_algorithm": 8.477,
-        "validation": 9358.694
+        "search_algorithm": 10.609,
+        "validation": 10682.389
       },
-      "timestamp": "2026-03-13 09:44:4 UTC"
+      "timestamp": "2026-04-21 07:24:11 UTC"
     },
     {
       "compilation_data": {
@@ -516,49 +516,49 @@
         {
           "name": "time",
           "unit": "",
-          "value": 44.256
+          "value": 37.28
         },
         {
           "name": "dram__throughput.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 71.57711330935251
+          "value": 59.375
         },
         {
           "name": "dram__sectors_read.sum",
           "type": "Double",
           "unit": "",
-          "value": 9788.0
+          "value": 8052.0
         },
         {
           "name": "dram__sectors_write.sum",
           "type": "Double",
           "unit": "",
-          "value": 41152.0
+          "value": 35876.0
         },
         {
           "name": "lts__t_sectors.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 74.65849479972103
+          "value": 71.74489409433907
         },
         {
           "name": "lts__t_sectors_op_read.sum",
           "type": "Double",
           "unit": "",
-          "value": 262462.0
+          "value": 262412.0
         },
         {
           "name": "lts__t_sectors_op_write.sum",
           "type": "Double",
           "unit": "",
-          "value": 131348.0
+          "value": 131452.0
         },
         {
           "name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 13.352566766908714
+          "value": 12.70998747153945
         },
         {
           "name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.sum",
@@ -570,7 +570,7 @@
           "name": "l1tex__data_pipe_lsu_wavefronts_mem_shared.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 5.5507372072853425
+          "value": 5.328268702925604
         },
         {
           "name": "l1tex__data_pipe_lsu_wavefronts_mem_shared_op_ld.sum",
@@ -600,13 +600,13 @@
           "name": "sm__warps_active.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 62.16194625776604
+          "value": 63.523824277027664
         },
         {
           "name": "smsp__cycles_active.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 82.55620527970513
+          "value": 79.16661246471452
         },
         {
           "name": "smsp__sass_thread_inst_executed_op_fp16_pred_on.sum",
@@ -666,7 +666,7 @@
           "name": "smsp__pipe_fma_cycles_active.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 15.128991154364646
+          "value": 15.14068668329013
         },
         {
           "name": "smsp__inst_executed_pipe_fp64.avg.pct_of_peak_sustained_active",
@@ -684,7 +684,7 @@
           "name": "smsp__inst_executed_pipe_lsu.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 13.447171387006293
+          "value": 13.46089857084759
         },
         {
           "name": "smsp__inst_executed_pipe_tex.avg.pct_of_peak_sustained_active",
@@ -696,7 +696,7 @@
           "name": "smsp__issue_active.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 25.45905584999969
+          "value": 25.48442885252905
         },
         {
           "name": "smsp__thread_inst_executed_per_inst_executed.ratio",
@@ -715,19 +715,19 @@
         "time"
       ],
       "times": {
-        "compilation_time": 12721.594,
-        "data": 4697.985,
-        "framework": 38527.655,
-        "kernel_overhead": 8903.951,
-        "profiling_overhead": 3881.076,
-        "profiling_runs": 21044.643,
+        "compilation_time": 8168.616,
+        "data": 49589.34,
+        "framework": 116322.867,
+        "kernel_overhead": 8168.616,
+        "profiling_overhead": 67884.65,
+        "profiling_runs": 3521.295,
         "runtimes": [
-          44.256
+          37.28
         ],
-        "search_algorithm": 9.675,
-        "validation": 9290.56
+        "search_algorithm": 11.733,
+        "validation": 10375.416
       },
-      "timestamp": "2026-03-13 09:44:4 UTC"
+      "timestamp": "2026-04-21 07:24:11 UTC"
     },
     {
       "compilation_data": {
@@ -756,49 +756,49 @@
         {
           "name": "time",
           "unit": "",
-          "value": 44.576
+          "value": 47.232
         },
         {
           "name": "dram__throughput.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 72.94351374570446
+          "value": 72.0936433447099
         },
         {
           "name": "dram__sectors_read.sum",
           "type": "Double",
           "unit": "",
-          "value": 10632.0
+          "value": 9836.0
         },
         {
           "name": "dram__sectors_write.sum",
           "type": "Double",
           "unit": "",
-          "value": 43708.0
+          "value": 44240.0
         },
         {
           "name": "lts__t_sectors.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 71.22926120761916
+          "value": 70.75498462952854
         },
         {
           "name": "lts__t_sectors_op_read.sum",
           "type": "Double",
           "unit": "",
-          "value": 262455.0
+          "value": 262415.0
         },
         {
           "name": "lts__t_sectors_op_write.sum",
           "type": "Double",
           "unit": "",
-          "value": 131700.0
+          "value": 131492.0
         },
         {
           "name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 13.16272035445509
+          "value": 13.212130742355791
         },
         {
           "name": "l1tex__t_requests_pipe_lsu_mem_global_op_ld.sum",
@@ -810,7 +810,7 @@
           "name": "l1tex__data_pipe_lsu_wavefronts_mem_shared.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 5.2921264115351825
+          "value": 5.247178488617876
         },
         {
           "name": "l1tex__data_pipe_lsu_wavefronts_mem_shared_op_ld.sum",
@@ -840,13 +840,13 @@
           "name": "sm__warps_active.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 63.26284267038368
+          "value": 63.19614965388448
         },
         {
           "name": "smsp__cycles_active.avg.pct_of_peak_sustained_elapsed",
           "type": "Double",
           "unit": "",
-          "value": 79.48432937543606
+          "value": 79.40737051792829
         },
         {
           "name": "smsp__sass_thread_inst_executed_op_fp16_pred_on.sum",
@@ -906,7 +906,7 @@
           "name": "smsp__pipe_fma_cycles_active.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 14.978992866565715
+          "value": 14.868937535479173
         },
         {
           "name": "smsp__inst_executed_pipe_fp64.avg.pct_of_peak_sustained_active",
@@ -924,7 +924,7 @@
           "name": "smsp__inst_executed_pipe_lsu.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 13.316150373587144
+          "value": 13.21584748215076
         },
         {
           "name": "smsp__inst_executed_pipe_tex.avg.pct_of_peak_sustained_active",
@@ -936,7 +936,7 @@
           "name": "smsp__issue_active.avg.pct_of_peak_sustained_active",
           "type": "Double",
           "unit": "",
-          "value": 25.225932723328103
+          "value": 25.035920300792817
         },
         {
           "name": "smsp__thread_inst_executed_per_inst_executed.ratio",
@@ -955,19 +955,19 @@
         "time"
       ],
       "times": {
-        "compilation_time": 12673.4,
-        "data": 4649.726,
-        "framework": 37830.429,
-        "kernel_overhead": 8500.152,
-        "profiling_overhead": 3821.577,
-        "profiling_runs": 20858.974,
+        "compilation_time": 8263.589,
+        "data": 49852.799,
+        "framework": 117093.403,
+        "kernel_overhead": 8263.589,
+        "profiling_overhead": 68183.775,
+        "profiling_runs": 3554.769,
         "runtimes": [
-          44.576
+          47.232
         ],
-        "search_algorithm": 3.471,
-        "validation": 9406.798
+        "search_algorithm": 4.079,
+        "validation": 10471.088
       },
-      "timestamp": "2026-03-13 09:44:4 UTC"
+      "timestamp": "2026-04-21 07:24:11 UTC"
     }
   ],
   "schema_version": "1.0.0"


### PR DESCRIPTION
I have thoroughly inspected and look into how we measure overheads. During this, I encountered a few bugs or unintended behaviours. This pull request fixes them.

They include:
- accounting for profiling infrastructure overhead (CUPTI initialization and counters collection) in KernelResult.m_ProfilingOverhead, not in KernelResult.m_Overhead
- passing the kernel duration of the first run (i.e. without profiling) into the kernel result of the last pass (as these are later used in output files) only after the accounting for the overheads, not before
- refactoring total overhead calculation, as this included double counting of some overheads and omitted some

Open to suggestions.