### PR TITLE
FIX: include compiler options in KernelComputeData unique ID generation

### DIFF
--- a/Source/ComputeEngine/KernelComputeData.cpp
+++ b/Source/ComputeEngine/KernelComputeData.cpp
@@ -113,7 +113,7 @@ const std::string& KernelComputeData::GetTemplatedName() const
 
 KernelComputeId KernelComputeData::GetUniqueIdentifier() const
 {
-    KernelComputeId id = m_Name + m_TemplatedName + m_ConfigurationPrefix;
+    KernelComputeId id = m_Name + m_TemplatedName + m_ConfigurationPrefix + m_CompilerOptions;
     const auto symbolArguments = KernelArgument::GetArgumentsWithMemoryType(m_Arguments, ArgumentMemoryType::Symbol);
     
     for (const auto* argument : symbolArguments)


### PR DESCRIPTION
Compiler options must be included in KernelComputeData unique ID. Otherwise, kernels that differ only by compiler options generate identical IDs. That resulted in incorrectly reusing cached kernels instead of creating new ones in CudaEngine::LoadKernel(). (same for OpenCL and C++)
