### PR TITLE
Add fluid simulation example

### DIFF
--- a/Examples/FluidSimulation/README.md
+++ b/Examples/FluidSimulation/README.md
@@ -1,0 +1,16 @@
+# Fluid Simulation
+
+Real-time 3D Smoothed Particle Hydrodynamics (SPH) fluid simulator.
+CUDA-accelerated solver with dynamic autotuning,
+rendered through OpenGL with CUDA–GL interop.
+
+GitHub repository: https://github.com/petbab/fluid-simulation
+
+## Build
+Quick build script (doesn't install dependencies)
+```
+./quick-build.sh
+```
+
+For a full setup guide, see [fluid-simulation/README.md](https://github.com/petbab/fluid-simulation/blob/main/README.md).
+

--- a/Examples/FluidSimulation/quick-build.sh
+++ b/Examples/FluidSimulation/quick-build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [ ! -d fluid-simulation ]; then
+	git clone https://github.com/petbab/fluid-simulation.git || {
+		echo "Failed clone" >&2; exit 1
+	}
+fi
+
+cd fluid-simulation
+
+if [ ! -f cmake/CMakeUserConfig.cmake ]; then
+	sed 's/path\/to\/KTT/..\/..\/../g' cmake/CMakeUserConfig.cmake.in > cmake/CMakeUserConfig.cmake
+fi
+
+rm -rf build 2>/dev/null
+
+cmake -B build || {
+	echo "Failed CMake setup, make sure 'cmake/CMakeUserConfig.cmake' is configured" >&2; exit 1
+}
+
+cmake --build build -j $(nproc) || {
+	echo "Failed build" >&2; exit 1
+}
+
+cd ..
+
+echo "Run scene: ./fluid-simulation/build/bin/<scene>"
+echo "Available scenes:"
+ls fluid-simulation/build/bin
+


### PR DESCRIPTION
Adds https://github.com/petbab/fluid-simulation as an external example. The script `quick-build.sh` clones the repository and attempts to build the executables (no dependency install).