### PR TITLE
New methods for managing compiler options

### DIFF
--- a/Source/ComputeEngine/ComputeEngine.cpp
+++ b/Source/ComputeEngine/ComputeEngine.cpp
@@ -1,0 +1,8 @@
+#include "ComputeEngine.h"
+
+using namespace ktt;
+using namespace std;
+
+ComputeEngine::ComputeEngine(GlobalSizeType globalSizeType) :
+    m_Configuration(globalSizeType)
+{}

--- a/Source/ComputeEngine/ComputeEngine.cpp
+++ b/Source/ComputeEngine/ComputeEngine.cpp
@@ -6,3 +6,16 @@ using namespace std;
 ComputeEngine::ComputeEngine(GlobalSizeType globalSizeType) :
     m_Configuration(globalSizeType)
 {}
+
+string ComputeEngine::GetCompilerOptions()
+{
+    return m_Configuration.GetStaticCompilerOptions();
+}
+
+void ComputeEngine::AddCompilerOptions(const std::string& options)
+{
+    std::string allOptions = GetCompilerOptions();
+    allOptions += " ";
+    allOptions += options;
+    SetCompilerOptions(allOptions, true);
+}

--- a/Source/ComputeEngine/ComputeEngine.h
+++ b/Source/ComputeEngine/ComputeEngine.h
@@ -78,6 +78,8 @@ public:
 
     // Utility methods
     virtual void SetCompilerOptions(const std::string& options, const bool overrideDefault = false) = 0;
+    virtual std::string GetCompilerOptions();
+    virtual void AddCompilerOptions(const std::string& options);
     virtual void SetGlobalSizeType(const GlobalSizeType type) = 0;
     virtual void SetAutomaticGlobalSizeCorrection(const bool flag) = 0;
     virtual void SetKernelCacheCapacity(const uint64_t capacity) = 0;

--- a/Source/ComputeEngine/ComputeEngine.h
+++ b/Source/ComputeEngine/ComputeEngine.h
@@ -9,6 +9,7 @@
 #include <Api/Info/PlatformInfo.h>
 #include <Api/Output/ComputationResult.h>
 #include <ComputeEngine/ComputeApi.h>
+#include <ComputeEngine/EngineConfiguration.h>
 #include <ComputeEngine/KernelComputeData.h>
 #include <ComputeEngine/GlobalSizeType.h>
 #include <ComputeEngine/TransferResult.h>
@@ -86,6 +87,11 @@ public:
 
     // Sanitizing processor to isolate measurements (L2 cache flushing etc.)
     virtual void Sanitize(const QueueId /*queueId*/) {}
+
+protected:
+    explicit ComputeEngine(ktt::GlobalSizeType globalSizeType);
+
+    EngineConfiguration m_Configuration;
 };
 
 } // namespace ktt

--- a/Source/ComputeEngine/Cpp/CppEngine.cpp
+++ b/Source/ComputeEngine/Cpp/CppEngine.cpp
@@ -24,7 +24,7 @@ namespace ktt
 {
 
 CppEngine::CppEngine(const PlatformIndex platformIndex, const DeviceIndex deviceIndex, const uint32_t queueCount) :
-    m_Configuration(GlobalSizeType::OpenCL), // TODO: decide appropriate global size type for C++
+    ComputeEngine(GlobalSizeType::OpenCL), // TODO: decide appropriate global size type for C++
     m_PlatformIndex(platformIndex),
     m_DeviceIndex(deviceIndex),
     m_DeviceInfo(0, ""),
@@ -51,7 +51,7 @@ CppEngine::CppEngine(const PlatformIndex platformIndex, const DeviceIndex device
 }
 
 CppEngine::CppEngine(const ComputeApiInitializer& initializer, std::vector<QueueId>& assignedQueueIds) :
-    m_Configuration(GlobalSizeType::OpenCL),
+    ComputeEngine(GlobalSizeType::OpenCL),
     m_DeviceInfo(0, ""),
     m_KernelCache(10)
 {

--- a/Source/ComputeEngine/Cpp/CppEngine.h
+++ b/Source/ComputeEngine/Cpp/CppEngine.h
@@ -203,7 +203,6 @@ private:
         std::vector<std::future<ComputationResult>> pendingActions;
     };
 
-    EngineConfiguration m_Configuration;
     PlatformIndex m_PlatformIndex;
     DeviceIndex m_DeviceIndex;
     DeviceInfo m_DeviceInfo;

--- a/Source/ComputeEngine/Cuda/CudaEngine.cpp
+++ b/Source/ComputeEngine/Cuda/CudaEngine.cpp
@@ -31,7 +31,7 @@ namespace ktt
 {
 
 CudaEngine::CudaEngine(const DeviceIndex deviceIndex, const uint32_t queueCount) :
-    m_Configuration(GlobalSizeType::CUDA),
+    ComputeEngine(GlobalSizeType::CUDA),
     m_DeviceIndex(deviceIndex),
     m_DeviceInfo(0, ""),
     m_KernelCache(10),
@@ -85,7 +85,7 @@ CudaEngine::CudaEngine(const DeviceIndex deviceIndex, const uint32_t queueCount)
 }
 
 CudaEngine::CudaEngine(const ComputeApiInitializer& initializer, std::vector<QueueId>& assignedQueueIds) :
-    m_Configuration(GlobalSizeType::CUDA),
+    ComputeEngine(GlobalSizeType::CUDA),
     m_DeviceIndex(0),
     m_DeviceInfo(0, ""),
     m_KernelCache(10),

--- a/Source/ComputeEngine/Cuda/CudaEngine.h
+++ b/Source/ComputeEngine/Cuda/CudaEngine.h
@@ -104,7 +104,6 @@ public:
     void Sanitize(const QueueId queueId) override;
 
 private:
-    EngineConfiguration m_Configuration;
     DeviceIndex m_DeviceIndex;
     DeviceInfo m_DeviceInfo;
     IdGenerator<QueueId> m_QueueIdGenerator;

--- a/Source/ComputeEngine/EngineConfiguration.cpp
+++ b/Source/ComputeEngine/EngineConfiguration.cpp
@@ -38,6 +38,11 @@ std::string EngineConfiguration::GetCompilerOptions() const
     return m_StaticCompilerOptions + m_TuningCompilerOptions;
 }
 
+std::string EngineConfiguration::GetStaticCompilerOptions() const
+{
+    return m_StaticCompilerOptions;
+}
+
 GlobalSizeType EngineConfiguration::GetGlobalSizeType() const
 {
     return m_GlobalSizeType;

--- a/Source/ComputeEngine/EngineConfiguration.h
+++ b/Source/ComputeEngine/EngineConfiguration.h
@@ -19,6 +19,7 @@ public:
     void SetGlobalSizeCorrection(const bool sizeCorrection);
 
     std::string GetCompilerOptions() const;
+    std::string GetStaticCompilerOptions() const;
     GlobalSizeType GetGlobalSizeType() const;
     bool GetGlobalSizeCorrection() const;
 

--- a/Source/ComputeEngine/OpenCl/OpenClEngine.cpp
+++ b/Source/ComputeEngine/OpenCl/OpenClEngine.cpp
@@ -1,3 +1,4 @@
+#include "ComputeEngine/ComputeEngine.h"
 #ifdef KTT_API_OPENCL
 
 #include <Api/KttException.h>
@@ -23,7 +24,7 @@ namespace ktt
 {
 
 OpenClEngine::OpenClEngine(const PlatformIndex platformIndex, const DeviceIndex deviceIndex, const uint32_t queueCount) :
-    m_Configuration(GlobalSizeType::OpenCL),
+    ComputeEngine(GlobalSizeType::OpenCL),
     m_PlatformIndex(platformIndex),
     m_DeviceIndex(deviceIndex),
     m_DeviceInfo(0, ""),
@@ -84,7 +85,7 @@ OpenClEngine::OpenClEngine(const PlatformIndex platformIndex, const DeviceIndex 
 }
 
 OpenClEngine::OpenClEngine(const ComputeApiInitializer& initializer, std::vector<QueueId>& assignedQueueIds) :
-    m_Configuration(GlobalSizeType::OpenCL),
+    ComputeEngine(GlobalSizeType::OpenCL),
     m_PlatformIndex(0),
     m_DeviceIndex(0),
     m_DeviceInfo(0, ""),

--- a/Source/ComputeEngine/OpenCl/OpenClEngine.h
+++ b/Source/ComputeEngine/OpenCl/OpenClEngine.h
@@ -98,7 +98,6 @@ public:
     void Sanitize(const QueueId queueId) override;
 
 private:
-    EngineConfiguration m_Configuration;
     PlatformIndex m_PlatformIndex;
     DeviceIndex m_DeviceIndex;
     DeviceInfo m_DeviceInfo;

--- a/Source/ComputeEngine/Vulkan/VulkanEngine.cpp
+++ b/Source/ComputeEngine/Vulkan/VulkanEngine.cpp
@@ -14,7 +14,7 @@ namespace ktt
 {
 
 VulkanEngine::VulkanEngine(const DeviceIndex deviceIndex, const uint32_t queueCount) :
-    m_Configuration(GlobalSizeType::Vulkan),
+    ComputeEngine(GlobalSizeType::Vulkan),
     m_DeviceIndex(deviceIndex),
     m_DeviceInfo(0, ""),
     m_PipelineCache(10)

--- a/Source/ComputeEngine/Vulkan/VulkanEngine.h
+++ b/Source/ComputeEngine/Vulkan/VulkanEngine.h
@@ -97,7 +97,6 @@ public:
     void SetCompiler(const std::string& compiler) override;
 
 private:
-    EngineConfiguration m_Configuration;
     DeviceIndex m_DeviceIndex;
     DeviceInfo m_DeviceInfo;
     IdGenerator<ComputeActionId> m_ComputeIdGenerator;

--- a/Source/Tuner.cpp
+++ b/Source/Tuner.cpp
@@ -926,6 +926,31 @@ void Tuner::SetCompilerOptions(const std::string& options, const bool overrideDe
     }
 }
 
+std::string Tuner::GetCompilerOptions()
+{
+    try
+    {
+        return m_Tuner->GetCompilerOptions();
+    }
+    catch (const KttException& exception)
+    {
+        TunerCore::Log(LoggingLevel::Error, exception.what());
+        return std::string();
+    }
+}
+
+void Tuner::AddCompilerOptions(const std::string& options)
+{
+    try
+    {
+        m_Tuner->AddCompilerOptions(options);
+    }
+    catch (const KttException& exception)
+    {
+        TunerCore::Log(LoggingLevel::Error, exception.what());
+    }
+}
+
 void Tuner::SetGlobalSizeType(const GlobalSizeType type)
 {
     try

--- a/Source/Tuner.h
+++ b/Source/Tuner.h
@@ -1049,6 +1049,19 @@ public:
       */
     void SetCompilerOptions(const std::string& options, const bool overrideDefault = false);
 
+    /** @fn std::string GetCompilerOptions()
+      * Returns the currently set compute API compiler options.
+      * @return Currently set compiler options.
+      */
+    std::string GetCompilerOptions();
+
+    /** @fn void AddCompilerOptions(const std::string& options)
+      * Adds the specified options to the currently set compute API compiler options. The options are automatically prepended with a single
+      * space character.
+      * @param options Compiler options that will be appended.
+      */
+    void AddCompilerOptions(const std::string& options);
+
     /** @fn void SetCompiler(const std::string& compiler)
       * Sets the compiler executable to use for kernel compilation. This is only supported for the C++ backend.
       * For CUDA, OpenCL, and Vulkan backends, this method will throw an exception since they use built-in compilers.

--- a/Source/TunerCore.cpp
+++ b/Source/TunerCore.cpp
@@ -457,6 +457,16 @@ void TunerCore::SetCompilerOptions(const std::string& options, const bool overri
     m_ComputeEngine->SetCompilerOptions(options, overrideDefault);
 }
 
+std::string TunerCore::GetCompilerOptions()
+{
+    return m_ComputeEngine->GetCompilerOptions();
+}
+
+void TunerCore::AddCompilerOptions(const std::string& options)
+{
+    m_ComputeEngine->AddCompilerOptions(options);
+}
+
 void TunerCore::SetCompiler(const std::string& compiler)
 {
     m_ComputeEngine->SetCompiler(compiler);

--- a/Source/TunerCore.h
+++ b/Source/TunerCore.h
@@ -123,6 +123,8 @@ public:
     void SynchronizeDevice();
     void SetProfilingCounters(const std::vector<std::string>& counters);
     void SetCompilerOptions(const std::string& options, const bool overrideDefault = false);
+    std::string GetCompilerOptions();
+    void AddCompilerOptions(const std::string& options);
     void SetCompiler(const std::string& compiler);
     void SetGlobalSizeType(const GlobalSizeType type);
     void SetAutomaticGlobalSizeCorrection(const bool flag);


### PR DESCRIPTION
This will let users add compiler options or get their current state. Particularly useful for Examples.

Doing this without undue code duplication required pulling up m_Configuration from ComputeEngine implementations, which also means that ComputeEngine is no longer a pure abstract class. 

I can revert this step and keep ComputeEngine as is, and push the new methods down into each inheriting engine instead.
However, I think a better solution would be to actually go further in my direction and pull up even more duplicated code.