### PR TITLE
Add optional graceful interrupt to Tuner::Tune

### DIFF
--- a/Source/Tuner.cpp
+++ b/Source/Tuner.cpp
@@ -721,6 +721,18 @@ KernelConfiguration Tuner::GetBestConfiguration(const KernelId id) const
     }
 }
 
+void Tuner::SetUseGracefulInterrupt(bool use)
+{
+    try
+    {
+        m_Tuner->SetUseGracefulInterrupt(use);
+    }
+    catch (const KttException& exception)
+    {
+        TunerCore::Log(LoggingLevel::Error, exception.what());
+    }
+}
+
 KernelConfiguration Tuner::CreateConfiguration(const KernelId id, const ParameterInput& parameters) const
 {
     try

--- a/Source/Tuner.h
+++ b/Source/Tuner.h
@@ -905,6 +905,14 @@ public:
       */
     KernelConfiguration GetBestConfiguration(const KernelId id) const;
 
+    /** @fn void SetUseGracefulInterrupt(bool use)
+      * Toggles graceful interruption of kernel tuning through the Tune method. When enabled, a SIGINT handler is registered at the beginning of tuning, and the
+      * tuning is stopped after the currently tested configuration finishes instead of being terminated immediately. The results of
+      * configurations tested so far are returned. Graceful interruption is disabled by default.
+      * @param use If true, tuning will be gracefully interrupted when SIGINT is received. It will be terminated immediately otherwise.
+      */
+    void SetUseGracefulInterrupt(bool use);
+
     /** @fn KernelConfiguration CreateConfiguration(const KernelId id, const ParameterInput& parameters) const
       * Creates and returns configuration for the specified kernel based on provided parameters and their values.
       * @param id Id of kernel for which the configuration will be created.

--- a/Source/TunerCore.cpp
+++ b/Source/TunerCore.cpp
@@ -321,6 +321,11 @@ KernelConfiguration TunerCore::GetBestConfiguration(const KernelId id) const
     return m_TuningRunner->GetBestConfiguration(id);
 }
 
+void TunerCore::SetUseGracefulInterrupt(bool use)
+{
+    m_TuningRunner->SetUseGracefulInterrupt(use);
+}
+
 KernelConfiguration TunerCore::CreateConfiguration(const KernelId id, const ParameterInput& parameters) const
 {
     const auto& kernel = m_KernelManager->GetKernel(id);

--- a/Source/TunerCore.h
+++ b/Source/TunerCore.h
@@ -102,6 +102,7 @@ public:
     void ClearConfigurationData(const KernelId id);
     uint64_t GetConfigurationsCount(const KernelId id) const;
     KernelConfiguration GetBestConfiguration(const KernelId id) const;
+    void SetUseGracefulInterrupt(bool use);
     KernelConfiguration CreateConfiguration(const KernelId id, const ParameterInput& parameters) const;
     std::string GetKernelSource(const KernelId id, const KernelConfiguration& configuration) const;
     std::string GetKernelDefinitionSource(const KernelDefinitionId id, const KernelConfiguration& configuration) const;

--- a/Source/TuningRunner/TuningRunner.cpp
+++ b/Source/TuningRunner/TuningRunner.cpp
@@ -6,6 +6,7 @@
 #include <Utility/Logger/Logger.h>
 #include <Utility/Timer/ScopeTimer.h>
 #include <Utility/Timer/Timestamp.h>
+#include <Utility/InterruptHandler.h>
 
 namespace ktt
 {
@@ -45,6 +46,11 @@ std::vector<KernelResult> TuningRunner::Tune(const Kernel& kernel, const KernelD
         stopCondition->Initialize(configurationsCount);
     }
 
+    if (m_useGracefulInterrupt)
+    {
+        InterruptHandler::RegisterHandler();
+    }
+
     std::vector<KernelResult> results;
 //    KernelResult result(kernel.GetName(), m_ConfigurationManager->GetCurrentConfiguration(id));
 
@@ -77,6 +83,12 @@ std::vector<KernelResult> TuningRunner::Tune(const Kernel& kernel, const KernelD
         //no need to explicitly recompute total overhead here, as it is computed on demand in GetTotalOverhead() method,
         // now with an updated searcher overhead value
         results.push_back(result);
+
+        if (InterruptHandler::GetShouldInterrupt()) {
+            Logger::LogInfo("Tuning stopped due to SIGINT, returning...");
+            InterruptHandler::UnregisterHandler();
+            break;
+        }
 
         if (stopCondition == nullptr)
         {
@@ -244,6 +256,11 @@ uint64_t TuningRunner::GetConfigurationsCount(const KernelId id) const
 KernelConfiguration TuningRunner::GetBestConfiguration(const KernelId id) const
 {
     return m_ConfigurationManager->GetBestConfiguration(id);
+}
+
+void TuningRunner::SetUseGracefulInterrupt(bool use)
+{
+    m_useGracefulInterrupt = use;
 }
 
 const KernelResult& TuningRunner::FindMatchingResult(const std::vector<KernelResult>& results,

--- a/Source/TuningRunner/TuningRunner.h
+++ b/Source/TuningRunner/TuningRunner.h
@@ -34,10 +34,12 @@ public:
     void ClearConfigurationData(const KernelId id, const bool clearSearcher = false);
     uint64_t GetConfigurationsCount(const KernelId id) const;
     KernelConfiguration GetBestConfiguration(const KernelId id) const;
+    void SetUseGracefulInterrupt(bool use);
 
 private:
     KernelRunner& m_KernelRunner;
     std::unique_ptr<ConfigurationManager> m_ConfigurationManager;
+    bool m_useGracefulInterrupt = false;
 
     static const KernelResult& FindMatchingResult(const std::vector<KernelResult>& results, const KernelConfiguration& configuration);
 };

--- a/Source/Utility/InterruptHandler.cpp
+++ b/Source/Utility/InterruptHandler.cpp
@@ -1,0 +1,48 @@
+#include "InterruptHandler.h"
+#include "Utility/Logger/Logger.h"
+#include <cassert>
+#include <cerrno>
+#include <cstring>
+#include <string>
+#include <csignal>
+
+using namespace std;
+using namespace ktt;
+
+atomic<bool> InterruptHandler::m_shouldInterrupt = false;
+void (*InterruptHandler::m_oldHandler)(int) = nullptr;
+
+bool InterruptHandler::GetShouldInterrupt()
+{
+    return m_shouldInterrupt;
+}
+
+void InterruptHandler::RegisterHandler()
+{
+    m_oldHandler = signal(SIGINT, HandleInterrupt);
+    Logger::LogInfo("SIGINT handler registered");
+    if (m_oldHandler == SIG_ERR)
+    {
+        Logger::LogError("Could not install SIGINT handler, tuning will not save on Ctrl-C.");
+        Logger::LogError(string("Message: ") + strerror(errno));
+    }
+    if (m_oldHandler == SIG_IGN)
+    {
+        signal(SIGINT, SIG_IGN);  // Conventionally, if parent ignored signal, it should stay ignored
+        Logger::LogWarning("SIGINT was ignored before this call, not installing handler.");
+    }
+}
+
+void InterruptHandler::UnregisterHandler()
+{
+    assert(m_oldHandler != nullptr || m_oldHandler == SIG_DFL);
+    if (m_oldHandler != SIG_ERR)
+    {
+        signal(SIGINT, m_oldHandler);
+    }
+}
+
+void InterruptHandler::HandleInterrupt(int)
+{
+    m_shouldInterrupt = true;
+}

--- a/Source/Utility/InterruptHandler.h
+++ b/Source/Utility/InterruptHandler.h
@@ -1,0 +1,13 @@
+#include <atomic>
+
+class InterruptHandler 
+{
+public:
+    static bool GetShouldInterrupt();
+    static void RegisterHandler();
+    static void UnregisterHandler();
+private:
+    static void HandleInterrupt(int signal);
+    static void (*m_oldHandler)(int);
+    static std::atomic<bool> m_shouldInterrupt;
+};


### PR DESCRIPTION
Disabled by default, can be enabled with `Tuner::SetUseGracefulInterrupt(bool)`.

When Ctrl-C is detected, waits for the last tuning iteration to complete, then stops the tuning and returns. 